### PR TITLE
CD: use bash for all environments

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -56,11 +56,13 @@ jobs:
           override: true
 
       - name: Sets env vars for push
+        shell: bash
         run: |
           echo "RELEASE_REF_NAME=${{ github.ref_name }}" >> $GITHUB_ENV
         if: ${{ github.event_name == 'push' }}
 
       - name: Sets env vars for pull request
+        shell: bash
         run: |
           echo "RELEASE_REF_NAME=pr${{ github.event.pull_request.number }}" >> $GITHUB_ENV
         if: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
In windows, powershell used by default

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/gifnksm/souko/blob/HEAD/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/gifnksm/souko/blob/HEAD/CHANGELOG.md
-->
