### PR TITLE
Add commandline flags to control output verbosity

### DIFF
--- a/src/bin/souko/cli.rs
+++ b/src/bin/souko/cli.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use clap::Parser;
+use tracing::Level;
 
 use crate::{project_dirs, util::OptionalParam};
 
@@ -12,6 +13,18 @@ pub(crate) use self::{clone::*, import::*};
 #[derive(Debug, Parser)]
 #[clap(author, version, about)]
 pub(crate) struct Args {
+    /// More output per occurrence
+    #[clap(long, short = 'v', parse(from_occurrences), global = true)]
+    verbose: i8,
+    /// Less output per occurrence
+    #[clap(
+        long,
+        short = 'q',
+        parse(from_occurrences),
+        global = true,
+        conflicts_with = "verbose"
+    )]
+    quiet: i8,
     /// Path to souko config file
     #[clap(long, env = "SOUKO_CONFIG")]
     config: Option<PathBuf>,
@@ -33,6 +46,18 @@ pub(crate) enum SubCommand {
 }
 
 impl Args {
+    pub(crate) fn verbosity(&self) -> Option<Level> {
+        let level = self.verbose - self.quiet;
+        match level {
+            i8::MIN..=-3 => None,
+            -2 => Some(Level::ERROR),
+            -1 => Some(Level::WARN),
+            0 => Some(Level::INFO),
+            1 => Some(Level::DEBUG),
+            2..=i8::MAX => Some(Level::TRACE),
+        }
+    }
+
     pub(crate) fn config(&'_ self) -> OptionalParam<'_, PathBuf> {
         OptionalParam::new("config", &self.config, || {
             project_dirs().config_dir().join("config.toml")


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/gifnksm/souko/blob/HEAD/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/gifnksm/souko/blob/HEAD/CHANGELOG.md
-->
