### PR TITLE
Add job to detect workflow completion

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -12,3 +12,10 @@ on:
 jobs:
   audit:
     uses: gifnksm/rust-template/.github/workflows/reusable-audit.yml@main
+
+  audit-complete:
+    needs: audit
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Audit completed"
+        shell: bash

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,3 +13,10 @@ jobs:
     uses: gifnksm/rust-template/.github/workflows/reusable-cd.yml@main
     with:
       upload-dist-archive: true
+
+  cd-complete:
+    needs: cd
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "CD completed"
+        shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,3 +12,10 @@ env:
 jobs:
   ci:
     uses: gifnksm/rust-template/.github/workflows/reusable-ci.yml@main
+
+  ci-complete:
+    needs: ci
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "CI completed"
+        shell: bash


### PR DESCRIPTION
GitHub's auto-merge feature can be triggered when these jobs completed

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/gifnksm/souko/blob/HEAD/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/gifnksm/souko/blob/HEAD/CHANGELOG.md
-->
