### PR TITLE
release.toml: remove dev-version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1112,7 +1112,7 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "souko"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "assert_cmd",
  "assert_fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["xtask"]
 
 [package]
 name = "souko"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 edition = "2021"
 rust-version = "1.62.1"
 description = "A simple command line utility that provides an easy way to organize clones of remote git repositories"

--- a/release.toml
+++ b/release.toml
@@ -9,4 +9,3 @@ pre-release-replacements = [
   {file = "src/lib.rs", search = "^#!\\[doc\\(html_root_url = \"https://docs.rs/souko/.*\"\\)\\]$", replace = "#![doc(html_root_url = \"https://docs.rs/souko/{{version}}\")]", exactly = 1},
 ]
 pre-release-hook = ["cargo", "test"]
-dev-version = true


### PR DESCRIPTION
cargo-release removed dev-version support

https://github.com/crate-ci/cargo-release/releases/tag/v0.22.0

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/gifnksm/souko/blob/HEAD/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/gifnksm/souko/blob/HEAD/CHANGELOG.md
-->
