### PR TITLE
config.toml: `query` and `root` are now optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Fixed
+
+* config.toml: `query` and `root` are now optional.
+
 ## [0.1.0] - 2023-09-02
 
 * First release

--- a/src/presentation/config/mod.rs
+++ b/src/presentation/config/mod.rs
@@ -12,9 +12,9 @@ use crate::domain::model::{query::ParseOption, root::Root};
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(super) struct Config {
-    #[serde(rename = "root")]
+    #[serde(rename = "root", default)]
     root_map: RootMap,
-    #[serde(rename = "query")]
+    #[serde(rename = "query", default)]
     query_config: QueryConfig,
 }
 


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/gifnksm/souko/blob/HEAD/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/gifnksm/souko/blob/HEAD/CHANGELOG.md
-->
