### PR TITLE
(breaking change) Use system `libgit2` and `libopenssl` by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+* (breaking change) Use system `libgit2` and `libopenssl` by default
+  * If you want to use `souko` command without system dependencies, please build `souko` with`--features vendored-libgit2,vendored-libopenssl` flag.
+
 ## [0.1.2] - 2023-09-03
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ predicates = "3.0.3"
 [build-dependencies]
 
 [features]
-default = ["vendored-libgit2", "vendored-openssl"]
+default = []
 vendored-libgit2 = ["git2/vendored-libgit2"]
 vendored-openssl = ["git2/vendored-openssl"]
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -12,6 +12,7 @@ fn main() -> Result<()> {
         let target = package
             .binary_by_name(command.get_name())?
             .command(command)
+            .cargo_build_options(vec!["--features", "vendored-libgit2,vendored-openssl"])
             .build()?;
         let dist = dist.package(package.target(target).build()?).build()?;
         let config = ConfigBuilder::new().dist(dist).build()?;


### PR DESCRIPTION
<!-- Please explain the changes you made -->
If you want to use `souko` command without system dependencies, please build `souko` with`--features vendored-libgit2,vendored-libopenssl` flag.
<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/gifnksm/souko/blob/HEAD/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/gifnksm/souko/blob/HEAD/CHANGELOG.md
-->
