### PR TITLE
chore: add .editorconfig and improve dependabot config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.rs]
+indent_size = 4
+
+[*.toml]
+indent_size = 2
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,14 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
   - package-ecosystem: "cargo"
     directory: "/"
+    allow:
+      - dependency-type: "all"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    groups:
+      patch-only:
+        update-types:
+          - "patch"


### PR DESCRIPTION
## Summary

### Add `.editorconfig`
Adds a project-wide EditorConfig file to ensure consistent editor settings across contributors.

- Default: UTF-8, LF line endings, space indent (4 spaces), insert final newline, trim trailing whitespace
- Rust (`.rs`): 4-space indent
- TOML / YAML: 2-space indent
- Markdown: preserve trailing whitespace (required for some Markdown formatting)
- Makefile: tab indent (required by make)

### Update `.github/dependabot.yml`
Improves the Dependabot configuration to reduce noise and better organize updates.

- Change update schedule from **daily → weekly** for both GitHub Actions and Cargo
- Allow all dependency types (`dependency-type: all`) for Cargo
- Group Cargo patch-level updates together (`patch-only` group)
