### PR TITLE
ci: add concurrency settings to cancel outdated workflow runs

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -9,6 +9,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
+
 jobs:
   audit:
     uses: gifnksm/rust-template/.github/workflows/reusable-audit.yml@main

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,6 +8,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
+
 jobs:
   cd:
     uses: gifnksm/rust-template/.github/workflows/reusable-cd.yml@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
## Summary

Add `concurrency` settings to the CI, CD, and Security Audit workflows so that outdated runs are automatically cancelled when a new push or pull request update is triggered.

## Changes

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
```

- **Group**: uniquely identified by workflow name + PR number (for PRs) or ref (for pushes)
- **Cancel condition**: cancels in-progress runs on any branch other than the default branch, preserving important builds on `main`