### PR TITLE
chore: migrate from cli-xtask to just-based tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,9 @@ jobs:
       os: ${{ steps.set-values.outputs.os }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
       - uses: Swatinem/rust-cache@v2
       - name: Set matrix values
         id: set-values
@@ -41,6 +43,153 @@ jobs:
           jq -n --argjson rust "${rust}" --argjson os "${os}" '{ rust: $rust, os: $os }'
         shell: bash
 
+  rustfmt:
+    name: Rustfmt
+    strategy:
+      fail-fast: true
+      matrix:
+        rust: [stable]
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          components: rustfmt
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: just
+      - run: just ci-rustfmt
+        shell: bash
+
+  check:
+    name: Check
+    needs: set-matrix
+    strategy:
+      fail-fast: true
+      matrix:
+        rust: ${{ fromJSON(needs.set-matrix.outputs.rust) }}
+        os: ${{ fromJSON(needs.set-matrix.outputs.os) }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: just,cargo-hack
+      - uses: Swatinem/rust-cache@v2
+      - run: just ci-check
+        shell: bash
+
+  clippy:
+    name: Clippy
+    needs: set-matrix
+    strategy:
+      fail-fast: true
+      matrix:
+        rust: [stable]
+        os: ${{ fromJSON(needs.set-matrix.outputs.os) }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          components: clippy
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: just,cargo-hack
+      - uses: Swatinem/rust-cache@v2
+      - run: just ci-clippy
+        shell: bash
+
+  rustdoc:
+    name: Rustdoc
+    needs: set-matrix
+    strategy:
+      fail-fast: true
+      matrix:
+        rust: [stable]
+        os: ${{ fromJSON(needs.set-matrix.outputs.os) }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: just,cargo-hack
+      - uses: Swatinem/rust-cache@v2
+      - run: just ci-rustdoc
+        shell: bash
+
+  docs-rs:
+    name: Docs.rs
+    needs: set-matrix
+    strategy:
+      fail-fast: true
+      matrix:
+        rust: [nightly]
+        os: ${{ fromJSON(needs.set-matrix.outputs.os) }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: just,cargo-hack,cargo-docs-rs
+      - uses: Swatinem/rust-cache@v2
+      - run: just ci-docs-rs
+        shell: bash
+
+  sync-rdme:
+    name: Sync Readme
+    needs: set-matrix
+    strategy:
+      fail-fast: true
+      matrix:
+        rust: [nightly]
+        os: ${{ fromJSON(needs.set-matrix.outputs.os) }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: just,cargo-hack,cargo-sync-rdme
+      - uses: Swatinem/rust-cache@v2
+      - run: just ci-sync-rdme
+        shell: bash
+
+  machete:
+    name: Machete
+    needs: set-matrix
+    strategy:
+      fail-fast: true
+      matrix:
+        rust: [stable]
+        os: ${{ fromJSON(needs.set-matrix.outputs.os) }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: just,cargo-machete
+      - uses: Swatinem/rust-cache@v2
+      - run: just ci-machete
+        shell: bash
+
   test:
     name: Test
     needs: set-matrix
@@ -56,7 +205,10 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
       - uses: Swatinem/rust-cache@v2
-      - run: cargo xtask test --exhaustive
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: just,cargo-hack
+      - run: just ci-test
         shell: bash
 
   coverage:
@@ -77,23 +229,22 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@v2
         with:
-          tool: cargo-llvm-cov
-      - run: cargo llvm-cov --workspace --all-features --codecov --output-path codecov.json
+          tool: just,cargo-llvm-cov
+      - run: just ci-coverage
         shell: bash
       - uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: codecov.json
+          files: target/codecov.json
           fail_ci_if_error: false
 
-  build:
-    name: Build
-    needs: set-matrix
+  release-dry-run:
+    name: Release dry run
     strategy:
       fail-fast: true
       matrix:
-        rust: ${{ fromJSON(needs.set-matrix.outputs.rust) }}
-        os: ${{ fromJSON(needs.set-matrix.outputs.os) }}
+        rust: [stable]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -101,43 +252,9 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
       - uses: Swatinem/rust-cache@v2
-      - run: cargo xtask build --exhaustive -- --all-targets
-        shell: bash
-
-  lint:
-    name: Lint
-    needs: set-matrix
-    strategy:
-      fail-fast: true
-      matrix:
-        os: ${{ fromJSON(needs.set-matrix.outputs.os) }}
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt,clippy
-      - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@v2
         with:
-          tool: cargo-udeps,cargo-sync-rdme
-      - run: rustup toolchain add nightly --profile minimal
-        shell: bash
-      - run: cargo xtask lint --exhaustive
-        shell: bash
-
-  release-dry-run:
-    name: Release dry run
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-udeps,cargo-sync-rdme,cargo-release
-      - run: rustup toolchain add nightly --profile minimal
-        shell: bash
+          tool: cargo-release,just
       - run: cargo release patch -vv --allow-branch '*'
         shell: bash
 
@@ -155,10 +272,15 @@ jobs:
   ci-complete:
     needs:
       - set-matrix
+      - rustfmt
+      - check
+      - clippy
+      - rustdoc
+      - docs-rs
+      - sync-rdme
+      - machete
       - test
       - coverage
-      - build
-      - lint
       - release-dry-run
       - actionlint
     runs-on: ubuntu-latest

--- a/justfile
+++ b/justfile
@@ -1,0 +1,116 @@
+# Public tasks for this repository.
+
+# Format all crates in the workspace.
+fmt *args:
+    cargo fmt --all {{ args }}
+
+# Run all compile checks.
+check-all *args:
+    just check-default-target {{ args }}
+    just check-tests {{ args }}
+    just check-benches {{ args }}
+
+# Check default targets across exhaustive feature patterns.
+check-default-target *args:
+    cargo hack check --workspace --feature-powerset {{ args }}
+
+# Check test targets across exhaustive feature patterns.
+check-tests *args:
+    cargo hack check --workspace --feature-powerset --tests {{ args }}
+
+# Check benchmark targets across exhaustive feature patterns.
+check-benches *args:
+    cargo hack check --workspace --feature-powerset --benches {{ args }}
+
+# Run all clippy checks.
+clippy-all *args:
+    just clippy-default-target {{ args }}
+    just clippy-tests {{ args }}
+    just clippy-benches {{ args }}
+
+# Run clippy for default targets across exhaustive feature patterns.
+clippy-default-target *args:
+    cargo hack clippy --workspace --feature-powerset {{ args }}
+
+# Run clippy for test targets across exhaustive feature patterns.
+clippy-tests *args:
+    cargo hack clippy --workspace --feature-powerset --tests {{ args }}
+
+# Run clippy for benchmark targets across exhaustive feature patterns.
+clippy-benches *args:
+    cargo hack clippy --workspace --feature-powerset --benches {{ args }}
+
+# Run tests across exhaustive feature patterns.
+test-all *args:
+    cargo hack test --workspace --feature-powerset {{ args }}
+
+# Build coverage report.
+llvm-cov-all *args:
+    # Internal note: intentionally uses --all-features (not --feature-powerset).
+    # Reason: powerset-style repeated runs can overwrite codecov output.
+    cargo llvm-cov --workspace --all-features {{ args }}
+
+# Build docs across exhaustive feature patterns.
+doc-all *args:
+    cargo hack doc --workspace --feature-powerset {{ args }}
+
+# Build docs.rs-compatible docs for all packages.
+docs-rs-all *args:
+    rustup run nightly cargo hack docs-rs {{ args }}
+
+# Synchronize README snippets for all packages.
+sync-rdme-all *args:
+    rustup run nightly cargo hack sync-rdme --workspace {{ args }}
+
+# Detect unused dependencies.
+machete *args:
+    cargo machete {{ args }}
+
+# Run all CI-equivalent checks.
+ci: ci-rustfmt ci-check ci-clippy ci-rustdoc ci-docs-rs ci-sync-rdme ci-machete ci-test ci-coverage
+
+# CI: formatting must be clean.
+ci-rustfmt:
+    just fmt --check
+
+# CI: compile checks.
+ci-check:
+    just check-all
+
+# CI: clippy warnings are treated as errors.
+ci-clippy:
+    just clippy-all -- -D warnings
+
+# CI: rustdoc warnings are treated as errors.
+[env("RUSTDOCFLAGS", x'${RUSTDOCFLAGS:-} -D warnings')]
+ci-rustdoc:
+    just doc-all --no-deps
+
+# CI: docs.rs warnings are treated as errors.
+[env("RUSTDOCFLAGS", x'${RUSTDOCFLAGS:-} -D warnings')]
+ci-docs-rs:
+    just docs-rs-all
+
+# CI: README sync must produce no diff.
+ci-sync-rdme:
+    just sync-rdme-all --check
+
+# CI: dependency hygiene.
+ci-machete:
+    just machete
+
+# CI: test suite.
+ci-test:
+    just test-all
+
+# CI: uploadable coverage artifact.
+ci-coverage:
+    just llvm-cov-all --codecov --output-path target/codecov.json
+
+# Pre-release gate is equivalent to full CI.
+pre-release:
+    if [ -n "${GITHUB_ACTIONS:-}" ]; then \
+        echo "Skip pre-release CI on GitHub Actions (GITHUB_ACTIONS=${GITHUB_ACTIONS})"; \
+    else \
+        just ci; \
+    fi

--- a/release.toml
+++ b/release.toml
@@ -8,4 +8,4 @@ pre-release-replacements = [
   {file = "src/lib.rs", search = "^//! souko = \".*\"$", replace = "//! souko = \"{{version}}\"", exactly = 1},
   {file = "src/lib.rs", search = "^#!\\[doc\\(html_root_url = \"https://docs.rs/souko/.*\"\\)\\]$", replace = "#![doc(html_root_url = \"https://docs.rs/souko/{{version}}\")]", exactly = 1},
 ]
-pre-release-hook = ["cargo", "test"]
+pre-release-hook = ["just", "pre-release"]


### PR DESCRIPTION
## Summary
- migrate project tasks from `cli-xtask` to a `just`-based workflow
- remove `xtask` crate files and update project/release configuration
- split CI checks into task-specific jobs and invoke `just` recipes directly
- run MSRV only for `check` and `test`; keep lint/doc/tooling jobs on stable/nightly as appropriate
- keep coverage generation on `--all-features` and emit `target/codecov.json` for Codecov upload
- skip `pre-release` CI execution on GitHub Actions (`GITHUB_ACTIONS` guard) to avoid duplicate work in `release-dry-run`

## Notes
- CI tasks were intentionally split to improve parallelism and throughput
- `llvm-cov` intentionally uses `--all-features` (rather than feature powerset)
- recipe descriptions were added for `just --list` output

## Validation
- reviewed parity and intentional behavior changes against previous `cli-xtask` behavior
- checked workflow/recipe consistency (coverage output path, job dependencies, matrix scopes, list output)
