### PR TITLE
ci: add typos check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,6 +269,17 @@ jobs:
           ./actionlint -color
         shell: bash
 
+  typos:
+    name: Typos
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: typos
+      - name: Check spelling of entire workspace
+        run: typos
+
   ci-complete:
     needs:
       - set-matrix
@@ -283,6 +294,7 @@ jobs:
       - coverage
       - release-dry-run
       - actionlint
+      - typos
     runs-on: ubuntu-latest
     if: ${{ always() }}
     permissions: {}

--- a/src/domain/model/scheme.rs
+++ b/src/domain/model/scheme.rs
@@ -69,8 +69,8 @@ mod tests {
     #[test]
     fn test_parse() {
         assert!(Scheme::from_str("foo123").is_ok());
-        assert!(Scheme::from_str("fo").is_ok());
-        assert!(Scheme::from_str("fo+.-").is_ok());
+        assert!(Scheme::from_str("foo").is_ok());
+        assert!(Scheme::from_str("foo+.-").is_ok());
         assert!(Scheme::from_str("foo_bar").is_err());
         assert!(Scheme::from_str("23foo").is_err());
     }

--- a/src/infrastructure/fs_clone_repo.rs
+++ b/src/infrastructure/fs_clone_repo.rs
@@ -34,26 +34,27 @@ impl CloneRepo for FsCloneRepo {
         path: &dyn PathLike,
         bare: bool,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
-        let mut cb = git2::RemoteCallbacks::new();
+        let mut callback = git2::RemoteCallbacks::new();
         let git_config =
             git2::Config::open_default().map_err(|err| Error::OpenConfig { source: err })?;
-        let mut ch = CredentialHandler::new(git_config);
-        cb.credentials(move |url, username, allowed| {
-            ch.try_next_credential(url, username, allowed)
+        let mut credential_handler = CredentialHandler::new(git_config);
+        callback.credentials(move |url, username, allowed| {
+            credential_handler.try_next_credential(url, username, allowed)
         });
 
-        let mut po = git2::ProxyOptions::new();
-        po.auto();
+        let mut proxy_opt = git2::ProxyOptions::new();
+        proxy_opt.auto();
 
-        let mut fo = git2::FetchOptions::new();
-        fo.remote_callbacks(cb)
-            .proxy_options(po)
+        let mut fetch_opt = git2::FetchOptions::new();
+        fetch_opt
+            .remote_callbacks(callback)
+            .proxy_options(proxy_opt)
             .download_tags(git2::AutotagOption::All)
             .update_fetchhead(true);
 
         let _repo = git2::build::RepoBuilder::new()
             .bare(bare)
-            .fetch_options(fo)
+            .fetch_options(fetch_opt)
             .clone(url.as_str(), path.as_real_path())
             .map_err(|err| Error::Clone {
                 url: url.clone(),

--- a/src/util/file.rs
+++ b/src/util/file.rs
@@ -45,7 +45,7 @@ where
         .parent()
         .ok_or_else(|| eyre!("failed to get parent directory: {}", path.display()))?;
     fs::create_dir_all(dir)
-        .wrap_err_with(|| format!("failed to create diretory: {}", dir.display()))?;
+        .wrap_err_with(|| format!("failed to create directory: {}", dir.display()))?;
 
     let file = NamedTempFile::new_in(dir)
         .wrap_err_with(|| format!("failed to create temporary file in {}", dir.display(),))?;


### PR DESCRIPTION
Add a typos job to CI workflows to check spelling across the workspace.

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/gifnksm/souko/blob/HEAD/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/gifnksm/souko/blob/HEAD/CHANGELOG.md
-->
