### PR TITLE
ci: use just commands for actionlint, typos, and markdownlint jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,12 +262,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - name: Check workflow files
-        run: |
-          bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
-          echo "::add-matcher::.github/actionlint-matcher.json"
-          ./actionlint -color
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: just
+      - name: Install actionlint
+        run: bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) && sudo mv actionlint /usr/local/bin/
         shell: bash
+      - run: just ci-actionlint
 
   typos:
     name: Typos
@@ -276,16 +277,18 @@ jobs:
       - uses: actions/checkout@v6
       - uses: taiki-e/install-action@v2
         with:
-          tool: typos
-      - name: Check spelling of entire workspace
-        run: typos
+          tool: just,typos
+      - run: just ci-typos
 
   markdownlint:
     name: Markdownlint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - run: npx markdownlint-cli .
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: just
+      - run: just ci-markdownlint
 
   ci-complete:
     needs:

--- a/justfile
+++ b/justfile
@@ -66,8 +66,20 @@ sync-rdme-all *args:
 machete *args:
     cargo machete {{ args }}
 
+# Check workflow files.
+actionlint *args:
+    actionlint {{ args }}
+
+# Check spelling of entire workspace.
+typos *args:
+    typos {{ args }}
+
+# Lint markdown files.
+markdownlint *args:
+    npx markdownlint-cli {{ args }} .
+
 # Run all CI-equivalent checks.
-ci: ci-rustfmt ci-check ci-clippy ci-rustdoc ci-docs-rs ci-sync-rdme ci-machete ci-test ci-coverage
+ci: ci-rustfmt ci-check ci-clippy ci-rustdoc ci-docs-rs ci-sync-rdme ci-machete ci-test ci-coverage ci-actionlint ci-typos ci-markdownlint
 
 # CI: formatting must be clean.
 ci-rustfmt:
@@ -98,6 +110,18 @@ ci-sync-rdme:
 # CI: dependency hygiene.
 ci-machete:
     just machete
+
+# CI: check workflow files.
+ci-actionlint:
+    just actionlint
+
+# CI: check spelling.
+ci-typos:
+    just typos
+
+# CI: lint markdown files.
+ci-markdownlint:
+    just markdownlint
 
 # CI: test suite.
 ci-test:


### PR DESCRIPTION
## Summary

Refactor CI lint jobs to use `just` commands instead of inline shell commands.

### Changes
- **`justfile`**: Add `actionlint`, `typos`, `markdownlint` recipes and their `ci-*` variants. Update `ci` recipe to include the new checks.
- **`.github/workflows/ci.yml`**: Update `actionlint`, `typos`, and `markdownlint` jobs to install `just` and run via `just ci-*` commands.

This makes it easier to run the same checks locally with `just ci`.