### PR TITLE
fix: allow omitted query map fields in config deserialization

### DIFF
--- a/src/presentation/config/mod.rs
+++ b/src/presentation/config/mod.rs
@@ -31,3 +31,86 @@ impl Config {
         self.query_config.clone().into()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // We intentionally deserialize only the `[query]` subtree in these tests.
+    //
+    // Why not deserialize top-level `Config`?
+    // - `Config` includes `root_map`.
+    // - `root_map` default construction depends on `ProjectDirs::get()`, which
+    //   requires global initialization and is unrelated to query-map regression coverage.
+    //
+    // This wrapper keeps the test focused on the real failure mode:
+    // deserializing nested `[query]` / `[query.custom_scheme]` when some query
+    // fields are omitted.
+    #[derive(Debug, Deserialize)]
+    #[serde(deny_unknown_fields)]
+    struct QueryOnlyWrapper {
+        #[serde(rename = "query")]
+        query_config: QueryConfig,
+    }
+
+    impl QueryOnlyWrapper {
+        fn into_parse_option(self) -> ParseOption {
+            self.query_config.into()
+        }
+    }
+
+    #[test]
+    fn deserialize_query_without_scheme_alias_applies_overrides_and_merges_defaults() {
+        let input = r#"
+            [query]
+            default_scheme = "gl"
+
+            [query.custom_scheme]
+            github = "https://example.com/{path}"
+            sourcehut = "https://git.sr.ht/~{path}"
+        "#;
+
+        let wrapper: QueryOnlyWrapper = toml_edit::de::from_str(input).unwrap();
+        let option = wrapper.into_parse_option();
+
+        assert_eq!(option.default_scheme, Some("gl".parse().unwrap()));
+        assert_eq!(
+            option.scheme_alias.get("gh"),
+            Some(&"github".parse().unwrap())
+        );
+        assert_eq!(
+            option.scheme_alias.get("gl"),
+            Some(&"gitlab".parse().unwrap())
+        );
+
+        let query =
+            crate::domain::model::query::Query::parse("github:gifnksm/souko", &option).unwrap();
+        assert_eq!(query.url().as_str(), "https://example.com/gifnksm/souko");
+
+        let query =
+            crate::domain::model::query::Query::parse("sourcehut:gifnksm/souko", &option).unwrap();
+        assert_eq!(query.url().as_str(), "https://git.sr.ht/~gifnksm/souko");
+
+        let query = crate::domain::model::query::Query::parse("gl:gifnksm/souko", &option).unwrap();
+        assert_eq!(query.url().as_str(), "https://gitlab.com/gifnksm/souko.git");
+    }
+
+    #[test]
+    fn deserialize_query_without_custom_scheme_keeps_default_schemes() {
+        let input = r#"
+            [query]
+            default_scheme = "gh"
+        "#;
+
+        let wrapper: QueryOnlyWrapper = toml_edit::de::from_str(input).unwrap();
+        let option = wrapper.into_parse_option();
+
+        assert_eq!(option.default_scheme, Some("gh".parse().unwrap()));
+
+        let query = crate::domain::model::query::Query::parse("gh:gifnksm/souko", &option).unwrap();
+        assert_eq!(query.url().as_str(), "https://github.com/gifnksm/souko.git");
+
+        let query = crate::domain::model::query::Query::parse("gl:gifnksm/souko", &option).unwrap();
+        assert_eq!(query.url().as_str(), "https://gitlab.com/gifnksm/souko.git");
+    }
+}

--- a/src/presentation/config/query.rs
+++ b/src/presentation/config/query.rs
@@ -94,37 +94,3 @@ impl From<QueryConfig> for ParseOption {
         }
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn deserialize_query_config_without_scheme_alias() {
-        let input = r#"
-            default_scheme = "gl"
-
-            [custom_scheme]
-            github = "https://example.com/{path}"
-            sourcehut = "https://git.sr.ht/~{path}"
-        "#;
-
-        let config: QueryConfig = toml_edit::de::from_str(input).unwrap();
-        let option: ParseOption = config.into();
-
-        assert_eq!(option.default_scheme, Some("gl".parse().unwrap()));
-        assert_eq!(
-            option.scheme_alias.get("gh"),
-            Some(&"github".parse().unwrap())
-        );
-        assert_eq!(
-            option.scheme_alias.get("gl"),
-            Some(&"gitlab".parse().unwrap())
-        );
-
-        assert!(option.custom_scheme.contains_key("github"));
-        assert!(option.custom_scheme.contains_key("gitlab"));
-        assert!(option.custom_scheme.contains_key("sourcehut"));
-        assert_eq!(option.custom_scheme.len(), 3);
-    }
-}


### PR DESCRIPTION
## Summary

Fix config deserialization so `query.scheme_alias` and `query.custom_scheme` can be omitted from config files without causing parse failures.

## Problem

With a config containing a `[query]` section but missing `scheme_alias`, souko failed to parse config with:

- `missing field 'scheme_alias' in 'query'`

## Changes

- In `src/presentation/config/query.rs`, added `#[serde(default)]` to fields in `ConfigRepr`:
  - `scheme_alias`
  - `custom_scheme`

This allows missing fields to deserialize as empty maps, after which existing defaults/merge behavior in `QueryConfig::deserialize` continues to work as intended.

## Tests

Added regression coverage under `presentation::config::tests` in `src/presentation/config/mod.rs`:

- `deserialize_query_without_scheme_alias_applies_overrides_and_merges_defaults`
- `deserialize_query_without_custom_scheme_keeps_default_schemes`

These tests deserialize nested `[query]` / `[query.custom_scheme]` TOML shape and verify effective query parsing behavior after merge.

## Validation

- Ran `cargo test` successfully.