### PR TITLE
Fix build-dist packaging

### DIFF
--- a/scripts/build-dist
+++ b/scripts/build-dist
@@ -74,16 +74,18 @@ main() {
             local env_prefix="${bin_name^^}"
             env_prefix="${env_prefix//-/_}"
 
+            local cargo_run=(cargo run -p "${pkg}" --bin "${bin_name}" "${build_options[@]}")
+
             mkdir -p "${BUILD_DIR}/completion"
-            env "${env_prefix}_COMPLETE=bash" cargo run -p "${pkg}" --bin "${bin_name}" >"${BUILD_DIR}/completion/${bin_name}.bash"
-            env "${env_prefix}_COMPLETE=elvish" cargo run -p "${pkg}" --bin "${bin_name}" >"${BUILD_DIR}/completion/${bin_name}.elv"
-            env "${env_prefix}_COMPLETE=fish" cargo run -p "${pkg}" --bin "${bin_name}" >"${BUILD_DIR}/completion/${bin_name}.fish"
-            env "${env_prefix}_COMPLETE=powershell" cargo run -p "${pkg}" --bin "${bin_name}" >"${BUILD_DIR}/completion/_${bin_name}.ps1"
-            env "${env_prefix}_COMPLETE=zsh" cargo run -p "${pkg}" --bin "${bin_name}" >"${BUILD_DIR}/completion/_${bin_name}"
-            env "${env_prefix}_COMPLETE=nushell" cargo run -p "${pkg}" --bin "${bin_name}" >"${BUILD_DIR}/completion/${bin_name}.nu"
+            env "${env_prefix}_COMPLETE=bash" "${cargo_run[@]}" >"${BUILD_DIR}/completion/${bin_name}.bash"
+            env "${env_prefix}_COMPLETE=elvish" "${cargo_run[@]}" >"${BUILD_DIR}/completion/${bin_name}.elv"
+            env "${env_prefix}_COMPLETE=fish" "${cargo_run[@]}" >"${BUILD_DIR}/completion/${bin_name}.fish"
+            env "${env_prefix}_COMPLETE=powershell" "${cargo_run[@]}" >"${BUILD_DIR}/completion/_${bin_name}.ps1"
+            env "${env_prefix}_COMPLETE=zsh" "${cargo_run[@]}" >"${BUILD_DIR}/completion/_${bin_name}"
+            env "${env_prefix}_COMPLETE=nushell" "${cargo_run[@]}" >"${BUILD_DIR}/completion/${bin_name}.nu"
 
             mkdir -p "${BUILD_DIR}/man"
-            env "${env_prefix}_GENERATE_MAN_TO=${BUILD_DIR}/man" cargo run -p "${pkg}" --bin "${bin_name}"
+            env "${env_prefix}_GENERATE_MAN_TO=${BUILD_DIR}/man" "${cargo_run[@]}"
         done
     done
 


### PR DESCRIPTION
## Motivation
- da86ba3 copied `scripts/build-dist` from another project and left package-specific settings pointing at the wrong package names
- that broke dist artifact generation for this repository
- vendored libgit2/openssl also make GitHub Release binaries more self-contained and reliable across targets

## Summary
- restore the correct `souko` package selection in `scripts/build-dist`
- enable vendored libgit2/openssl for distribution builds

## Testing
- verified the script changes against the broken `da86ba3` configuration
