### PR TITLE
Harden build-dist validation

### DIFF
--- a/scripts/build-dist
+++ b/scripts/build-dist
@@ -158,7 +158,11 @@ main() {
     done
 
     local version
-    version="$(jq -r '.packages[] | select(.name == $pkg) | .version' --arg pkg "${ROOT_PACKAGE}" "${metadata_json}" | tr -d '\r')"
+    if ! version="$(
+        jq -r '.packages[] | select(.name == $pkg) | .version' --arg pkg "${ROOT_PACKAGE}" "${metadata_json}" | tr -d '\r'
+    )"; then
+        die "failed to query cargo metadata for root package '${ROOT_PACKAGE}' version"
+    fi
     if [[ -z "${version}" || "${version}" == "null" ]]; then
         die "failed to resolve version for root package '${ROOT_PACKAGE}'"
     fi


### PR DESCRIPTION
## Motivation
- da86ba3 showed that `scripts/build-dist` could silently drift to the wrong package settings and only fail later in less obvious ways
- the dist script should fail fast when package metadata, binary targets, or version resolution do not match expectations

## Summary
- add explicit package existence checks for the root and distribution packages
- fail early when a distribution package has no binary targets
- validate that the expected built binary and root package version are present before packaging

## Testing
- cargo test
