### PR TITLE
Fix shellcheck warning in build-dist

### DIFF
--- a/scripts/build-dist
+++ b/scripts/build-dist
@@ -130,8 +130,10 @@ main() {
 
         local bin_name
         for bin_name in "${bin_names[@]}"; do
-            # shellcheck disable=SC2206
-            local build_options=(${PACKAGE_BUILD_OPTIONS["${pkg}"]})
+            local -a build_options=()
+            if [[ -n "${PACKAGE_BUILD_OPTIONS["${pkg}"]}" ]]; then
+                read -ra build_options <<<"${PACKAGE_BUILD_OPTIONS["${pkg}"]}"
+            fi
             "${cargo_build[@]}" --release -p "${pkg}" --bin "${bin_name}" "${target_option[@]}" "${build_options[@]}"
             local bin_file="${bin_name}${bin_suffix}"
             if [[ ! -f "${release_bin_dir}/${bin_file}" ]]; then


### PR DESCRIPTION
## Summary
- replace the unquoted array assignment in `scripts/build-dist` to avoid unintended glob expansion and word splitting
- parse package build options with `read -ra` before passing them as command arguments
- preserve the existing build invocation behavior for configured package options

## Validation
- `shellcheck scripts/build-dist`
- `git --no-pager diff --check`