### PR TITLE
Add zsh plugin and shell integration examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * Useful for integrating with picker tools such as fzf and skim
   * Available template variables include `root_name`, `repo_relative_path`, `repo_canonical_path`, etc.
   * Unknown variable names in templates are detected and reported as errors when running `souko list` (during `--template` argument validation)
+* Added shell integration documentation and a zsh plugin for selecting a repository with `sk` or `fzf` and changing to it from the current shell ([#658](https://github.com/gifnksm/souko/pull/658))
+  * Documented fuzzy-finder-based repository navigation in the README
+  * Added `souko.plugin.zsh` and `souko-cd-widget` with configurable selector and key binding options
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ VS Code extension [souko-vscode] is also available.
 
 [souko-vscode]: https://marketplace.visualstudio.com/items?itemName=gifnksm.souko
 
+## Quick start
+
 When you clone a remote repository with souko, souko creates a directory under a specific root directory (`~/.local/share/souko/root` by default) containing the hostname and path of the remote repository's URL.
 
 ```console
@@ -31,85 +33,11 @@ $ souko list
 # => list of absolute paths of all repositories cloned with souko
 ```
 
-For picker tools such as fzf/skim, you can customize each output line with `--template`.
+Use `--template` to customize the output format of `souko list`.
 
 ```console
 $ souko list --template $'{root_name}\t{repo_relative_path}\t{repo_canonical_path}'
 # => default    github.com/gifnksm/souko    /home/you/.local/share/souko/root/github.com/gifnksm/souko
-```
-
-`--template` uses souko's template variables (no extra escape-sequence processing is done by souko itself; quoting/escaping is handled by your shell).
-
-Terminology:
-
-- `root`: one `[[root]]` entry in config (for example, `default` or `repos`)
-- `repo`: each Git repository found under a root
-
-Available variables:
-
-- `{root_name}`
-- `{root_display_path}`
-- `{root_real_path}`
-- `{root_canonical_path}`
-- `{repo_relative_path}`
-- `{repo_display_path}`
-- `{repo_real_path}`
-- `{repo_canonical_path}`
-
-Path variable semantics:
-
-- `relative_path`: path relative to the selected root (for repositories, this is `{repo_relative_path}`)
-- `display_path`: user-facing path representation (may include `~` and may not be absolute)
-- `real_path`: absolute path before canonicalization (symlinks are not resolved)
-- `canonical_path`: canonical absolute path (symlinks resolved)
-
-By combining souko, fuzzy finder, and shell functions, you can easily jump between repositories.
-
-Example with skim (`sk`):
-
-```console
-$ repo_dir="$(
-    souko list --template $'{root_name} {repo_relative_path}\t{repo_canonical_path}' |
-      sk --delimiter $'\t' --with-nth 1 --nth 1 |
-      cut -f2
-  )"
-$ printf '%s\n' "$repo_dir"
-```
-
-Example with fzf:
-
-```console
-$ repo_dir="$(
-    souko list --template $'{root_name} {repo_relative_path}\t{repo_canonical_path}' |
-      fzf --delimiter=$'\t' --with-nth=1 |
-      cut -f2
-  )"
-$ printf '%s\n' "$repo_dir"
-```
-
-## Configuration
-
-Configuration is done via a TOML file located at `~/.config/souko/config.toml` by default.
-
-```toml
-[[root]]
-name = "default"
-path = "~/.local/share/souko/root"
-
-[[root]]
-name = "repos"
-path = "~/repos"
-
-[query]
-default_scheme = "github"
-
-[query.scheme_alias]
-gh = "github"
-gl = "gitlab"
-
-[query.custom_scheme]
-github = "https://github.com/{path}.git"
-gitlab = "https://gitlab.com/{path}.git"
 ```
 
 ## Installation
@@ -137,7 +65,183 @@ $ cargo binstall souko
 [GitHub Release page]: https://github.com/gifnksm/souko/releases/
 [`cargo-binstall`]: https://github.com/cargo-bins/cargo-binstall
 
-### Build from source using Rust
+## Shell integration
+
+By combining souko, fuzzy finder, and shell functions, you can easily jump between repositories.
+
+### Fuzzy finder examples
+
+Example with skim (`sk`):
+
+```console
+$ repo_dir="$(
+    souko list --template $'{root_name} {repo_relative_path}\t{repo_canonical_path}' |
+      sk --delimiter $'\t' --with-nth 1 --nth 1 |
+      cut -f2
+  )"
+$ printf '%s\n' "$repo_dir"
+```
+
+Example with fzf:
+
+```console
+$ repo_dir="$(
+    souko list --template $'{root_name} {repo_relative_path}\t{repo_canonical_path}' |
+      fzf --delimiter=$'\t' --with-nth=1 |
+      cut -f2
+  )"
+$ printf '%s\n' "$repo_dir"
+```
+
+### zsh plugin
+
+This repository includes a zsh plugin that adds a widget for changing to a repository selected from `souko list` with `sk` or `fzf`.
+
+By default, the plugin binds `Ctrl-g` to `souko-cd-widget`.
+
+#### Requirements
+
+The plugin requires:
+
+- `souko`
+- either `sk` or `fzf`
+
+#### Manual
+
+```zsh
+source /path/to/souko/souko.plugin.zsh
+```
+
+#### sheldon
+
+```zsh
+sheldon add --github gifnksm/souko
+sheldon sync
+```
+
+#### Behavior
+
+When invoked, the widget:
+
+1. runs `souko list --template ...`
+2. pipes the output to `sk` or `fzf`
+3. extracts the path from the selected line
+4. runs `cd` to change to the selected repository in the current shell
+
+The default template is:
+
+```zsh
+$'{root_name} {repo_relative_path}\t{repo_canonical_path}'
+```
+
+This means:
+
+- the text before the tab is displayed in the selector
+- the text after the tab is used as the destination path for `cd`
+
+##### Template contract
+
+`SOUKO_LIST_TEMPLATE` is customizable, but the widget expects each output line to follow this format:
+
+```text
+label<TAB>path
+```
+
+If the selected line contains a tab, the part after the first tab is used as the destination path.
+If the selected line does not contain a tab, the entire line is treated as the path.
+
+#### Configuration
+
+Set these before loading the plugin:
+
+```zsh
+export SOUKO_COMMAND=souko
+export SOUKO_SELECTOR=auto                 # auto|sk|fzf
+export SOUKO_LIST_TEMPLATE=$'{root_name} {repo_relative_path}\t{repo_canonical_path}'
+export SOUKO_KEY_CD_REPO='^G'              # Ctrl-g; set empty to disable automatic bindkey
+export SOUKO_SK_OPTS='--ansi'
+export SOUKO_SK_TMUX_OPTS='center,80%'
+export SOUKO_FZF_OPTS='--height=40%'
+export SOUKO_FZF_TMUX_OPTS='center,80%'
+```
+
+#### Example customizations
+
+Use `fzf` explicitly and change the key binding:
+
+```zsh
+export SOUKO_SELECTOR=fzf
+export SOUKO_KEY_CD_REPO='^R'
+source /path/to/souko/souko.plugin.zsh
+```
+
+Disable the default key binding and bind the widget yourself:
+
+```zsh
+export SOUKO_KEY_CD_REPO=
+source /path/to/souko/souko.plugin.zsh
+bindkey '^G' souko-cd-widget
+```
+
+Show a different label while preserving the required path format:
+
+```zsh
+export SOUKO_LIST_TEMPLATE=$'{repo_relative_path}\t{repo_canonical_path}'
+```
+
+## Configuration
+
+Configuration is done via a TOML file located at `~/.config/souko/config.toml` by default.
+
+```toml
+[[root]]
+name = "default"
+path = "~/.local/share/souko/root"
+
+[[root]]
+name = "repos"
+path = "~/repos"
+
+[query]
+default_scheme = "github"
+
+[query.scheme_alias]
+gh = "github"
+gl = "gitlab"
+
+[query.custom_scheme]
+github = "https://github.com/{path}.git"
+gitlab = "https://gitlab.com/{path}.git"
+```
+
+## Template variables and path semantics
+
+`--template` uses souko's template variables (no extra escape-sequence processing is done by souko itself; quoting/escaping is handled by your shell).
+
+Terminology:
+
+- `root`: one `[[root]]` entry in config (for example, `default` or `repos`)
+- `repo`: each Git repository found under a root
+
+Available variables:
+
+- `{root_name}`
+- `{root_display_path}`
+- `{root_real_path}`
+- `{root_canonical_path}`
+- `{repo_relative_path}`
+- `{repo_display_path}`
+- `{repo_real_path}`
+- `{repo_canonical_path}`
+
+Path variable semantics:
+
+- `relative_path`: path relative to the selected root (for repositories, this is `{repo_relative_path}`)
+- `display_path`: user-facing path representation (may include `~` and may not be absolute)
+- `real_path`: absolute path before canonicalization (symlinks are not resolved)
+- `canonical_path`: canonical absolute path (symlinks resolved)
+
+## Build from source using Rust
 
 To build souko executable from the source, you must have the Rust toolchain installed.
 To install the rust toolchain, follow [this guide](https://www.rust-lang.org/tools/install).

--- a/scripts/build-dist
+++ b/scripts/build-dist
@@ -162,6 +162,9 @@ main() {
 
     cp README.md "${BUILD_DIR}"
     cp LICENSE-* "${BUILD_DIR}"
+    cp souko.plugin.zsh "${BUILD_DIR}"
+    mkdir -p "${BUILD_DIR}/shell"
+    cp shell/key-bindings.zsh "${BUILD_DIR}/shell/"
 
     for pkg in "${DIST_PACKAGES[@]}"; do
         local -a bin_names=()

--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -1,0 +1,157 @@
+# souko key bindings for zsh
+# Customizable env vars (set before source):
+#     SOUKO_COMMAND          : souko command to execute (default: souko)
+#     SOUKO_SELECTOR         : auto|sk|fzf (default: auto)
+#     SOUKO_LIST_TEMPLATE    : template for `souko list --template` (default: '{root_name} {repo_relative_path}\t{repo_canonical_path}')
+#     SOUKO_KEY_CD_REPO      : bind key for cd widget (default: '^G' = Ctrl-g)
+#     SOUKO_SK_OPTS          : extra args for sk
+#     SOUKO_SK_TMUX_OPTS     : sk --tmux option value (default: center,80%)
+#     SOUKO_FZF_OPTS         : extra args for fzf
+#     SOUKO_FZF_TMUX_OPTS    : fzf --tmux option value (default: center,80%)
+
+: ${SOUKO_COMMAND:=souko}
+: ${SOUKO_SELECTOR:=auto}
+: ${SOUKO_LIST_TEMPLATE:=$'{root_name} {repo_relative_path}\t{repo_canonical_path}'}
+: ${SOUKO_KEY_CD_REPO='^G'}
+: ${SOUKO_SK_OPTS:=}
+: ${SOUKO_SK_TMUX_OPTS:=center,80%}
+: ${SOUKO_FZF_OPTS:=}
+: ${SOUKO_FZF_TMUX_OPTS:=center,80%}
+
+.souko_msg() {
+    local msg="$*"
+
+    if [[ -n "${WIDGET}" ]]; then
+        zle -M -- "${msg}"
+    else
+        print -u2 -- "${msg}"
+    fi
+}
+
+.souko_resolve_selector() {
+    builtin emulate -L zsh ${=${options[xtrace]:#off}:+-o xtrace}
+    builtin setopt extended_glob warn_create_global typeset_silent no_short_loops rc_quotes no_auto_pushd
+
+    case "${SOUKO_SELECTOR}" in
+        sk|fzf)
+            command -v "${SOUKO_SELECTOR}" >/dev/null 2>&1 || return 1
+            print -r -- "${SOUKO_SELECTOR}"
+            ;;
+        auto)
+            if command -v sk >/dev/null 2>&1; then
+                print -r -- "sk"
+            elif command -v fzf >/dev/null 2>&1; then
+                print -r -- "fzf"
+            else
+                return 1
+            fi
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+.souko_select_line() {
+    builtin emulate -L zsh ${=${options[xtrace]:#off}:+-o xtrace}
+    builtin setopt pipefail no_aliases extended_glob warn_create_global typeset_silent no_short_loops rc_quotes no_auto_pushd
+
+    local selector="$1" selected
+    local -a sk_opts fzf_opts
+
+    if [[ -n "${SOUKO_SK_OPTS}" ]]; then
+        sk_opts=("${(@z)SOUKO_SK_OPTS}")
+    fi
+    if [[ -n "${SOUKO_FZF_OPTS}" ]]; then
+        fzf_opts=("${(@z)SOUKO_FZF_OPTS}")
+    fi
+
+    case "${selector}" in
+        sk)
+            if [[ -n "${TMUX:-}" ]]; then
+                selected="$("${selector}" --delimiter $'\t' --with-nth 1 --nth 1 --tmux="${SOUKO_SK_TMUX_OPTS}" "${sk_opts[@]}")"
+            else
+                selected="$("${selector}" --delimiter $'\t' --with-nth 1 --nth 1 "${sk_opts[@]}")"
+            fi
+            ;;
+        fzf)
+            if [[ -n "${TMUX:-}" ]]; then
+                selected="$("${selector}" --delimiter $'\t' --with-nth 1 --nth 1 --tmux="${SOUKO_FZF_TMUX_OPTS}" "${fzf_opts[@]}")"
+            else
+                selected="$("${selector}" --delimiter $'\t' --with-nth 1 --nth 1 "${fzf_opts[@]}")"
+            fi
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+
+    [[ -n "${selected}" ]] || return 1
+    print -r -- "${selected}"
+}
+
+.souko_pick_repo_line() {
+    builtin emulate -L zsh ${=${options[xtrace]:#off}:+-o xtrace}
+    builtin setopt pipefail no_aliases extended_glob warn_create_global typeset_silent no_short_loops rc_quotes no_auto_pushd
+
+    command -v "${SOUKO_COMMAND}" >/dev/null 2>&1 || {
+        .souko_msg "${SOUKO_COMMAND}: command not found"
+        return 1
+    }
+
+    local selector selected
+    selector="$(.souko_resolve_selector)" || {
+        .souko_msg "${SOUKO_COMMAND}: neither sk nor fzf is available (or invalid SOUKO_SELECTOR)"
+        return 1
+    }
+
+    selected="$("${SOUKO_COMMAND}" list --template "${SOUKO_LIST_TEMPLATE}" | .souko_select_line "${selector}")" || return 1
+    print -r -- "${selected}"
+}
+
+# default contract: template outputs "label<TAB>path"
+.souko_extract_path_from_line() {
+    builtin emulate -L zsh ${=${options[xtrace]:#off}:+-o xtrace}
+    builtin setopt extended_glob warn_create_global typeset_silent no_short_loops rc_quotes no_auto_pushd
+
+    local line="$1"
+    if [[ "${line}" == *$'\t'* ]]; then
+        print -r -- "${line#*$'\t'}"
+    else
+        print -r -- "${line}"
+    fi
+}
+
+souko-cd-widget() {
+    builtin emulate -L zsh ${=${options[xtrace]:#off}:+-o xtrace}
+    builtin setopt extended_glob warn_create_global typeset_silent no_short_loops rc_quotes no_auto_pushd no_aliases
+
+    local MATCH REPLY
+    integer MBEGIN MEND
+    local -a match mbegin mend reply
+    local line repo_path
+    line="$(.souko_pick_repo_line)" || {
+        return 0
+    }
+
+    repo_path="$(.souko_extract_path_from_line "${line}")"
+    [[ -n "${repo_path}" ]] || {
+        return 0
+    }
+
+    builtin cd -- "${repo_path}" || {
+        .souko_msg "${SOUKO_COMMAND}: failed to cd: ${repo_path}"
+        return 0
+    }
+
+    zle reset-prompt
+    return 0
+}
+
+if [[ -o interactive ]]; then
+    zle -N souko-cd-widget
+
+    if [[ -n "${SOUKO_KEY_CD_REPO}" ]]; then
+        bindkey "${SOUKO_KEY_CD_REPO}" souko-cd-widget
+    fi
+fi

--- a/souko.plugin.zsh
+++ b/souko.plugin.zsh
@@ -1,0 +1,14 @@
+# souko zsh plugin entrypoint
+# Supports plugin managers and manual source.
+
+_souko_plugin_file="${ZERO:-${${0:#$ZSH_ARGZERO}:-${(%):-%N}}}"
+_souko_plugin_file="${${(M)_souko_plugin_file:#/*}:-$PWD/$_souko_plugin_file}"
+
+_souko_plugin_root="${_souko_plugin_file:h}"
+
+# Load key bindings only in interactive shells.
+if [[ -o interactive ]]; then
+    source "${_souko_plugin_root}/shell/key-bindings.zsh"
+fi
+
+unset _souko_plugin_file _souko_plugin_root


### PR DESCRIPTION
## Summary

- add a zsh plugin entrypoint at `souko.plugin.zsh`
- add a `souko-cd-widget` widget and default key binding
- support `sk` and `fzf` with configurable options
- document shell integration and zsh plugin usage in the README
- document the `SOUKO_LIST_TEMPLATE` contract for selector output
- add a changelog entry for the new shell integration support

## Details

The widget runs `souko list --template ...`, pipes the output to `sk` or `fzf`, extracts the selected path, and runs `cd` in the current shell.

The plugin is designed to work both with plugin managers and with manual `source`, and only initializes interactive shell bindings in interactive shells.

Closes #291