### PR TITLE
Fix zsh selector path-first template handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+* The zsh `souko-cd-widget` now uses a path-first tab-separated selector format so labels can contain tabs without breaking path extraction ([#660](https://github.com/gifnksm/souko/pull/660))
+  * Default `SOUKO_LIST_TEMPLATE` changed from `label<TAB>path` to `path<TAB>label`
+  * `sk`/`fzf` integration now displays and searches all label fields after the first tab while extracting the destination path from the first field
+  * If you customized `SOUKO_LIST_TEMPLATE`, update it to the new `path<TAB>label` contract
+  * README shell integration examples were updated to match the new selector contract
+
 ## [0.3.1] - 2026-04-03
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ Example with skim (`sk`):
 
 ```console
 $ repo_dir="$(
-    souko list --template $'{root_name} {repo_relative_path}\t{repo_canonical_path}' |
-      sk --delimiter $'\t' --with-nth 1 --nth 1 |
-      cut -f2
+    souko list --template $'{repo_canonical_path}\t{root_name} {repo_relative_path}' |
+      sk --delimiter $'\t' --with-nth 2.. --nth 1.. |
+      cut -f1
   )"
 $ printf '%s\n' "$repo_dir"
 ```
@@ -86,9 +86,9 @@ Example with fzf:
 
 ```console
 $ repo_dir="$(
-    souko list --template $'{root_name} {repo_relative_path}\t{repo_canonical_path}' |
-      fzf --delimiter=$'\t' --with-nth=1 |
-      cut -f2
+    souko list --template $'{repo_canonical_path}\t{root_name} {repo_relative_path}' |
+      fzf --delimiter=$'\t' --with-nth=2.. --nth=1.. |
+      cut -f1
   )"
 $ printf '%s\n' "$repo_dir"
 ```
@@ -131,23 +131,24 @@ When invoked, the widget:
 The default template is:
 
 ```zsh
-$'{root_name} {repo_relative_path}\t{repo_canonical_path}'
+$'{repo_canonical_path}\t{root_name} {repo_relative_path}'
 ```
 
 This means:
 
-- the text before the tab is displayed in the selector
-- the text after the tab is used as the destination path for `cd`
+- the text before the tab is used as the destination path for `cd`
+- the text after the tab is displayed and searched in the selector
+- if the label contains additional tabs, the selector continues to display and search the remaining label fields
 
 ##### Template contract
 
 `SOUKO_LIST_TEMPLATE` is customizable, but the widget expects each output line to follow this format:
 
 ```text
-label<TAB>path
+path<TAB>label
 ```
 
-If the selected line contains a tab, the part after the first tab is used as the destination path.
+If the selected line contains a tab, the part before the first tab is used as the destination path.
 If the selected line does not contain a tab, the entire line is treated as the path.
 
 #### Configuration
@@ -157,7 +158,7 @@ Set these before loading the plugin:
 ```zsh
 export SOUKO_COMMAND=souko
 export SOUKO_SELECTOR=auto                 # auto|sk|fzf
-export SOUKO_LIST_TEMPLATE=$'{root_name} {repo_relative_path}\t{repo_canonical_path}'
+export SOUKO_LIST_TEMPLATE=$'{repo_canonical_path}\t{root_name} {repo_relative_path}'
 export SOUKO_KEY_CD_REPO='^G'              # Ctrl-g; set empty to disable automatic bindkey
 export SOUKO_SK_OPTS='--ansi'
 export SOUKO_SK_TMUX_OPTS='center,80%'
@@ -186,7 +187,7 @@ bindkey '^G' souko-cd-widget
 Show a different label while preserving the required path format:
 
 ```zsh
-export SOUKO_LIST_TEMPLATE=$'{repo_relative_path}\t{repo_canonical_path}'
+export SOUKO_LIST_TEMPLATE=$'{repo_canonical_path}\t{repo_relative_path}'
 ```
 
 ## Configuration

--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -2,7 +2,7 @@
 # Customizable env vars (set before source):
 #     SOUKO_COMMAND          : souko command to execute (default: souko)
 #     SOUKO_SELECTOR         : auto|sk|fzf (default: auto)
-#     SOUKO_LIST_TEMPLATE    : template for `souko list --template` (default: '{root_name} {repo_relative_path}\t{repo_canonical_path}')
+#     SOUKO_LIST_TEMPLATE    : template for `souko list --template` (default: '{repo_canonical_path}\t{root_name} {repo_relative_path}')
 #     SOUKO_KEY_CD_REPO      : bind key for cd widget (default: '^G' = Ctrl-g)
 #     SOUKO_SK_OPTS          : extra args for sk
 #     SOUKO_SK_TMUX_OPTS     : sk --tmux option value (default: center,80%)
@@ -11,7 +11,7 @@
 
 : ${SOUKO_COMMAND:=souko}
 : ${SOUKO_SELECTOR:=auto}
-: ${SOUKO_LIST_TEMPLATE:=$'{root_name} {repo_relative_path}\t{repo_canonical_path}'}
+: ${SOUKO_LIST_TEMPLATE:=$'{repo_canonical_path}\t{root_name} {repo_relative_path}'}
 : ${SOUKO_KEY_CD_REPO='^G'}
 : ${SOUKO_SK_OPTS:=}
 : ${SOUKO_SK_TMUX_OPTS:=center,80%}
@@ -69,16 +69,16 @@
     case "${selector}" in
         sk)
             if [[ -n "${TMUX:-}" ]]; then
-                selected="$("${selector}" --delimiter $'\t' --with-nth 1 --nth 1 --tmux="${SOUKO_SK_TMUX_OPTS}" "${sk_opts[@]}")"
+                selected="$("${selector}" --delimiter $'\t' --with-nth 2.. --nth 1.. --tmux="${SOUKO_SK_TMUX_OPTS}" "${sk_opts[@]}")"
             else
-                selected="$("${selector}" --delimiter $'\t' --with-nth 1 --nth 1 "${sk_opts[@]}")"
+                selected="$("${selector}" --delimiter $'\t' --with-nth 2.. --nth 1.. "${sk_opts[@]}")"
             fi
             ;;
         fzf)
             if [[ -n "${TMUX:-}" ]]; then
-                selected="$("${selector}" --delimiter $'\t' --with-nth 1 --nth 1 --tmux="${SOUKO_FZF_TMUX_OPTS}" "${fzf_opts[@]}")"
+                selected="$("${selector}" --delimiter $'\t' --with-nth 2.. --nth 1.. --tmux="${SOUKO_FZF_TMUX_OPTS}" "${fzf_opts[@]}")"
             else
-                selected="$("${selector}" --delimiter $'\t' --with-nth 1 --nth 1 "${fzf_opts[@]}")"
+                selected="$("${selector}" --delimiter $'\t' --with-nth 2.. --nth 1.. "${fzf_opts[@]}")"
             fi
             ;;
         *)
@@ -109,14 +109,14 @@
     print -r -- "${selected}"
 }
 
-# default contract: template outputs "label<TAB>path"
+# default contract: template outputs "path<TAB>label"
 .souko_extract_path_from_line() {
     builtin emulate -L zsh ${=${options[xtrace]:#off}:+-o xtrace}
     builtin setopt extended_glob warn_create_global typeset_silent no_short_loops rc_quotes no_auto_pushd
 
     local line="$1"
     if [[ "${line}" == *$'\t'* ]]; then
-        print -r -- "${line#*$'\t'}"
+        print -r -- "${line%%$'\t'*}"
     else
         print -r -- "${line}"
     fi


### PR DESCRIPTION
## Summary

- change the zsh widget selector contract from `label<TAB>path` to `path<TAB>label`
- display the transformed label field in `sk`/`fzf` with `--with-nth 2 --nth 1`
- extract the destination path from the first field
- update README examples and plugin documentation
- document the change in CHANGELOG, including a note for custom `SOUKO_LIST_TEMPLATE` users

## Motivation

When the display label contains tabs, using `label<TAB>path` makes the first field unstable for `sk`/`fzf`.
Switching to `path<TAB>label` keeps path extraction stable while still showing and searching the label field.

## Notes

- the widget now expects `SOUKO_LIST_TEMPLATE` lines in `path<TAB>label` format
- if you customized `SOUKO_LIST_TEMPLATE`, update it to the new contract
- README examples were updated accordingly
