### PR TITLE
Fix duplicated GitHub release notes updates

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,11 +19,9 @@ env:
 permissions: {}
 
 jobs:
-  release:
-    name: Publishing for ${{ matrix.job.target }}
+  build-release-assets:
+    name: Build artifacts for ${{ matrix.job.target }}
     runs-on: ${{ matrix.job.os }}
-    permissions:
-      contents: write
     strategy:
       fail-fast: true
       matrix:
@@ -70,6 +68,22 @@ jobs:
           name: artifact-${{ matrix.job.target }}
           path: target/dist/*
 
+  release:
+    name: Create GitHub release
+    runs-on: ubuntu-latest
+    needs:
+      - build-release-assets
+    permissions:
+      contents: write
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    steps:
+      - name: Download built artifacts
+        uses: actions/download-artifact@v6
+        with:
+          pattern: artifact-*
+          path: target/dist
+          merge-multiple: true
+
       - name: Releasing assets
         uses: softprops/action-gh-release@v2
         with:
@@ -77,10 +91,10 @@ jobs:
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: ${{ startsWith(github.ref, 'refs/tags/') }}
 
   cd-complete:
     needs:
+      - build-release-assets
       - release
     runs-on: ubuntu-latest
     if: ${{ always() }}


### PR DESCRIPTION
## Summary

- split the release workflow into a matrix build job and a single GitHub release job
- upload per-target build outputs as workflow artifacts
- download and publish all release assets from one post-matrix job

## Motivation

The previous workflow ran `softprops/action-gh-release` in every matrix job. That allowed assets to accumulate correctly, but it also caused the GitHub release body to be regenerated repeatedly, resulting in duplicated release notes text.

## Notes

- `build-release-assets` now handles build and artifact upload only
- `release` now runs once after the matrix completes and publishes all downloaded artifacts
- no user-facing behavior changes are intended
