### PR TITLE
fix: include error chains in tracing output

### DIFF
--- a/src/application/service/root.rs
+++ b/src/application/service/root.rs
@@ -1,6 +1,7 @@
 use std::sync::{Arc, Mutex};
 
 use chrono::{DateTime, Duration, Utc};
+use color_eyre::eyre::eyre;
 
 use super::helper::workdir::Workdir;
 use crate::domain::{
@@ -19,6 +20,7 @@ use crate::domain::{
         walk_repo::{Entry, Repos, WalkRepo},
     },
 };
+use crate::util::error::format_error_chain;
 
 #[derive(Debug, Clone)]
 pub(crate) struct RootService {
@@ -73,7 +75,9 @@ impl RootService {
     ) {
         let mut repo_cache = self.repo_cache.lock().unwrap();
         if let Err(err) = repo_cache.load(path, now, expire_duration) {
-            tracing::warn!("failed to load repo cache: {err} ({})", path.display());
+            let err =
+                eyre!(err).wrap_err(format!("failed to load repo cache ({})", path.display()));
+            tracing::warn!("{}", format_error_chain(&err));
             repo_cache.clear(now);
         }
     }
@@ -81,7 +85,9 @@ impl RootService {
     pub(crate) fn store_repo_cache(&self, path: &dyn PathLike) {
         let mut repo_cache = self.repo_cache.lock().unwrap();
         if let Err(err) = repo_cache.store(path) {
-            tracing::warn!("failed to store repo cache: {err} ({})", path.display());
+            let err =
+                eyre!(err).wrap_err(format!("failed to store repo cache ({})", path.display()));
+            tracing::warn!("{}", format_error_chain(&err));
         }
     }
 

--- a/src/presentation/args/subcommand/list.rs
+++ b/src/presentation/args/subcommand/list.rs
@@ -18,6 +18,7 @@ use crate::{
     },
     presentation::{args::GlobalArgs, config::Config, model::optional_param::OptionalParam},
     project_dirs::ProjectDirs,
+    util::error::format_error_chain,
 };
 
 #[derive(Debug, Clone, Default, clap::Args)]
@@ -102,7 +103,7 @@ impl Args {
             match root_service.canonicalize_root(root.value(), should_exist) {
                 Ok(root) => root,
                 Err(e) => {
-                    tracing::warn!("{e}");
+                    tracing::warn!("{}", format_error_chain(&e));
                     None
                 }
             }
@@ -117,7 +118,7 @@ impl Args {
             let repos = match root_service.find_repos(root, skip_hidden, skip_bare, no_recursive) {
                 Ok(repos) => Some(repos),
                 Err(e) => {
-                    tracing::warn!("{e}");
+                    tracing::warn!("{}", format_error_chain(&e));
                     None
                 }
             };
@@ -125,7 +126,7 @@ impl Args {
             repos.into_iter().flatten().filter_map(|res| match res {
                 Ok(repo) => Some(repo),
                 Err(e) => {
-                    tracing::warn!("{e}");
+                    tracing::warn!("{}", format_error_chain(&e));
                     None
                 }
             })

--- a/src/util/error.rs
+++ b/src/util/error.rs
@@ -1,0 +1,28 @@
+use std::fmt::{self, Display, Formatter};
+
+pub(crate) fn format_error_chain<'a, E>(error: &'a E) -> ErrorChainDisplay<'a>
+where
+    E: AsRef<dyn std::error::Error> + 'a,
+{
+    ErrorChainDisplay {
+        error: error.as_ref(),
+    }
+}
+
+pub(crate) struct ErrorChainDisplay<'a> {
+    error: &'a dyn std::error::Error,
+}
+
+impl Display for ErrorChainDisplay<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.error)?;
+
+        let mut source = self.error.source();
+        while let Some(err) = source {
+            write!(f, "\n  caused by: {err}")?;
+            source = err.source();
+        }
+
+        Ok(())
+    }
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,1 +1,2 @@
+pub(crate) mod error;
 pub(crate) mod file;


### PR DESCRIPTION
## Summary
- add a helper to format error chains for tracing output
- wrap logged errors with context before formatting their chains
- use the helper in repository listing and repo cache warning paths

## Testing
- cargo test --quiet
- cargo clippy --no-default-features -- -D warnings