### PR TITLE
Allow AppDirs to absolutize relative paths

### DIFF
--- a/src/app_dirs.rs
+++ b/src/app_dirs.rs
@@ -1,9 +1,9 @@
 use std::{
     env,
-    path::{Path, PathBuf},
+    path::{self, Path, PathBuf},
 };
 
-use color_eyre::eyre::{Result, ensure, eyre};
+use color_eyre::eyre::{Result, WrapErr as _, eyre};
 use directories::BaseDirs;
 
 #[derive(Debug, Clone)]
@@ -65,16 +65,16 @@ impl AppDirs {
         cache_dir: S,
     ) -> Result<Self>
     where
-        P: AsRef<Path> + Into<PathBuf>,
-        Q: AsRef<Path> + Into<PathBuf>,
-        R: AsRef<Path> + Into<PathBuf>,
-        S: AsRef<Path> + Into<PathBuf>,
+        P: AsRef<Path>,
+        Q: AsRef<Path>,
+        R: AsRef<Path>,
+        S: AsRef<Path>,
     {
         Ok(Self {
-            home_dir: ensure_absolute_path("home_dir", home_dir)?.into(),
-            config_dir: ensure_absolute_path("config_dir", config_dir)?.into(),
-            data_local_dir: ensure_absolute_path("data_local_dir", data_local_dir)?.into(),
-            cache_dir: ensure_absolute_path("cache_dir", cache_dir)?.into(),
+            home_dir: make_absolute_path("home_dir", home_dir)?,
+            config_dir: make_absolute_path("config_dir", config_dir)?,
+            data_local_dir: make_absolute_path("data_local_dir", data_local_dir)?,
+            cache_dir: make_absolute_path("cache_dir", cache_dir)?,
         })
     }
 
@@ -95,14 +95,11 @@ impl AppDirs {
     }
 }
 
-fn ensure_absolute_path<P>(name: &str, path: P) -> Result<P>
+fn make_absolute_path<P>(name: &str, path: P) -> Result<PathBuf>
 where
     P: AsRef<Path>,
 {
-    ensure!(
-        path.as_ref().is_absolute(),
-        "{name} is not an absolute path: {}",
-        path.as_ref().display()
-    );
-    Ok(path)
+    let path = path.as_ref();
+    path::absolute(path)
+        .wrap_err_with(|| format!("failed to get absolute path for {name}: {}", path.display()))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use std::env;
 
 use clap::Parser as _;
-use color_eyre::eyre::{self, eyre};
+use color_eyre::eyre::{self, WrapErr as _, eyre};
 use tracing::level_filters::LevelFilter;
 use tracing_subscriber::EnvFilter;
 
@@ -54,6 +54,7 @@ fn main() -> eyre::Result<()> {
 
     let ports = infrastructure::ports();
     let usecases = Usecases::new(&ports);
-    let app_dirs = AppDirs::new(BIN_NAME)?;
+    let app_dirs =
+        AppDirs::new(BIN_NAME).wrap_err("failed to initialize application directories")?;
     presentation::dispatch(&args, usecases, app_dirs)
 }

--- a/tests/basic_usage.rs
+++ b/tests/basic_usage.rs
@@ -1,20 +1,26 @@
+use std::path::PathBuf;
+
 use assert_cmd::prelude::*;
 use assert_fs::{TempDir, fixture::ChildPath, prelude::*};
 use predicates::prelude::*;
 
 mod common;
 
-fn data_local_dir(home_dir: &impl PathChild) -> ChildPath {
+fn data_local_dir_path(home_dir: &std::path::Path) -> PathBuf {
     if cfg!(target_os = "linux") {
-        return home_dir.child(".local/share/souko");
+        return home_dir.join(".local/share/souko");
     }
     if cfg!(target_os = "macos") {
-        return home_dir.child("Library/Application Support/souko");
+        return home_dir.join("Library/Application Support/souko");
     }
     if cfg!(target_os = "windows") {
-        return home_dir.child(r"AppData\Local\souko\data");
+        return home_dir.join(r"AppData\Local\souko\data");
     }
     panic!("unsupported platform");
+}
+
+fn data_local_dir(home_dir: &impl PathChild) -> ChildPath {
+    home_dir.child(data_local_dir_path(std::path::Path::new("")).as_path())
 }
 
 #[test]
@@ -52,6 +58,46 @@ fn clone_and_list() {
                 data_local_dir(&home)
                     .child("root/github.com/gifnksm/souko")
                     .path()
+            )
+            .unwrap()
+            .display()
+        ));
+}
+
+#[test]
+fn relative_integration_test_home_is_absolutized() {
+    let workspace = TempDir::new().unwrap();
+    let relative_home = PathBuf::from("relative-home");
+
+    common::souko_cmd(&workspace)
+        .current_dir(workspace.path())
+        .env("HOME", &relative_home)
+        .env("SOUKO_INTEGRATION_TEST_HOME", &relative_home)
+        .args(["clone", "gifnksm/souko"])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+
+    let absolute_home = workspace.path().join(&relative_home);
+    assert!(
+        data_local_dir_path(&absolute_home)
+            .join("root/github.com/gifnksm/souko/.git")
+            .is_dir()
+    );
+
+    common::souko_cmd(&workspace)
+        .current_dir(workspace.path())
+        .env("HOME", &relative_home)
+        .env("SOUKO_INTEGRATION_TEST_HOME", &relative_home)
+        .args(["list"])
+        .assert()
+        .success()
+        .stdout(format!(
+            "{}\n",
+            dunce::canonicalize(
+                data_local_dir_path(&absolute_home)
+                    .join("root/github.com/gifnksm/souko")
+                    .as_path()
             )
             .unwrap()
             .display()


### PR DESCRIPTION
## Summary
- allow `AppDirs` to accept relative paths by converting them to absolute paths with `std::path::absolute`
- keep `AppDirs` values stable for downstream `UnresolvedPath::normalize_with_home` processing
- add startup context when application directory initialization fails

## Motivation
`AppDirs` is used to assemble application paths and to provide the `home_dir` base for later path normalization. If a relative home path slips in through unusual environment configuration such as a relative `HOME` or `SOUKO_INTEGRATION_TEST_HOME`, downstream normalization can behave unexpectedly because it would use a relative base path.

This change makes `AppDirs` defensively convert its inputs to absolute paths up front. The intent is path construction stability, not filesystem existence validation, so non-existent directories remain acceptable just as before.

## Testing
- `cargo test`