### PR TITLE
Resolve relative paths based on their input source

### DIFF
--- a/src/app_dirs.rs
+++ b/src/app_dirs.rs
@@ -8,6 +8,7 @@ use directories::BaseDirs;
 
 #[derive(Debug, Clone)]
 pub(crate) struct AppDirs {
+    working_dir: PathBuf,
     home_dir: PathBuf,
     config_dir: PathBuf,
     data_local_dir: PathBuf,
@@ -17,14 +18,18 @@ pub(crate) struct AppDirs {
 impl AppDirs {
     pub(crate) fn new(app_name: &str) -> Result<Self> {
         if let Some(home_dir) = env::var_os("SOUKO_INTEGRATION_TEST_HOME") {
-            return Self::new_for_test(app_name, home_dir);
+            let working_dir =
+                env::current_dir().wrap_err("failed to get current working directory")?;
+            return Self::new_for_test(app_name, home_dir, working_dir);
         }
 
+        let working_dir = env::current_dir().wrap_err("failed to get current working directory")?;
         let base_dirs = BaseDirs::new().ok_or_else(|| eyre!("failed to get base directories"))?;
         let project_dirs = directories::ProjectDirs::from("", "", app_name)
             .ok_or_else(|| eyre!("failed to get project directories"))?;
 
         Self::from_dirs(
+            working_dir,
             base_dirs.home_dir(),
             project_dirs.config_dir(),
             project_dirs.data_local_dir(),
@@ -32,8 +37,13 @@ impl AppDirs {
         )
     }
 
-    pub(crate) fn new_for_test(app_name: &str, home_dir: impl Into<PathBuf>) -> Result<Self> {
+    pub(crate) fn new_for_test(
+        app_name: &str,
+        home_dir: impl Into<PathBuf>,
+        working_dir: impl Into<PathBuf>,
+    ) -> Result<Self> {
         let home_dir = home_dir.into();
+        let working_dir = working_dir.into();
         let (config_dir, data_local_dir, cache_dir) = if cfg!(target_os = "windows") {
             (
                 home_dir.join(format!(r"AppData\Roaming\{app_name}\config")),
@@ -55,27 +65,34 @@ impl AppDirs {
         } else {
             return Err(eyre!("unsupported platform: {}", std::env::consts::OS));
         };
-        Self::from_dirs(home_dir, config_dir, data_local_dir, cache_dir)
+        Self::from_dirs(working_dir, home_dir, config_dir, data_local_dir, cache_dir)
     }
 
-    fn from_dirs<P, Q, R, S>(
-        home_dir: P,
-        config_dir: Q,
-        data_local_dir: R,
-        cache_dir: S,
+    fn from_dirs<P, Q, R, S, T>(
+        working_dir: P,
+        home_dir: Q,
+        config_dir: R,
+        data_local_dir: S,
+        cache_dir: T,
     ) -> Result<Self>
     where
         P: AsRef<Path>,
         Q: AsRef<Path>,
         R: AsRef<Path>,
         S: AsRef<Path>,
+        T: AsRef<Path>,
     {
         Ok(Self {
+            working_dir: make_absolute_path("working_dir", working_dir)?,
             home_dir: make_absolute_path("home_dir", home_dir)?,
             config_dir: make_absolute_path("config_dir", config_dir)?,
             data_local_dir: make_absolute_path("data_local_dir", data_local_dir)?,
             cache_dir: make_absolute_path("cache_dir", cache_dir)?,
         })
+    }
+
+    pub(crate) fn working_dir(&self) -> &Path {
+        &self.working_dir
     }
 
     pub(crate) fn home_dir(&self) -> &Path {

--- a/src/presentation/context/global.rs
+++ b/src/presentation/context/global.rs
@@ -27,18 +27,17 @@ impl GlobalContext {
         usecases: Usecases,
         app_dirs: AppDirs,
     ) -> Result<Self> {
-        let config_path = args
-            .global_args()
-            .config_path(&app_dirs)
-            .map(|path| path.normalize_with_home(app_dirs.home_dir()));
+        let config_path = args.global_args().config_path(&app_dirs);
+        let config_path = config_path
+            .as_ref()
+            .map(|path| path.normalize(config_path.source(), &app_dirs));
         let config = load_config(&config_path)?;
-        let root_map = RootContextMap::new(&config.roots, &app_dirs);
+        let root_map = RootContextMap::new(config_path.value(), &config.roots, &app_dirs);
         let query = QueryContext::from_config(&config.query);
-        let repo_cache_path = args
-            .global_args()
-            .repo_cache_path(&app_dirs)
+        let repo_cache_path = args.global_args().repo_cache_path(&app_dirs);
+        let repo_cache_path = repo_cache_path
             .value()
-            .normalize_with_home(app_dirs.home_dir());
+            .normalize(repo_cache_path.source(), &app_dirs);
         Ok(Self {
             usecases,
             root_map,

--- a/src/presentation/context/mod.rs
+++ b/src/presentation/context/mod.rs
@@ -13,8 +13,8 @@ pub(in crate::presentation) mod root;
 
 #[derive(Debug)]
 pub(in crate::presentation) enum SubcommandContext {
-    Clone(CloneContext),
-    List(ListContext),
+    Clone(Box<CloneContext>),
+    List(Box<ListContext>),
 }
 
 impl SubcommandContext {
@@ -23,8 +23,10 @@ impl SubcommandContext {
         subcommand: &Subcommand,
     ) -> Result<Self> {
         match subcommand {
-            Subcommand::Clone(args) => Ok(Self::Clone(CloneContext::new(global_ctx, args)?)),
-            Subcommand::List(args) => Ok(Self::List(ListContext::new(global_ctx, args)?)),
+            Subcommand::Clone(args) => {
+                Ok(Self::Clone(Box::new(CloneContext::new(global_ctx, args)?)))
+            }
+            Subcommand::List(args) => Ok(Self::List(Box::new(ListContext::new(global_ctx, args)?))),
         }
     }
 }

--- a/src/presentation/context/root.rs
+++ b/src/presentation/context/root.rs
@@ -20,23 +20,29 @@ pub(in crate::presentation) struct RootContextMap {
 }
 
 impl RootContextMap {
-    pub(in crate::presentation) fn new(config: &[RootConfig], app_dirs: &AppDirs) -> Self {
+    pub(in crate::presentation) fn new(
+        config_path: &PrettyPath,
+        config: &[RootConfig],
+        app_dirs: &AppDirs,
+    ) -> Self {
         let mut map: BTreeMap<String, AppParam<RootContext>> = config
             .iter()
-            .map(|root_config| {
+            .map(|config| {
                 // A root entry present in the configuration file keeps
                 // `ConfigurationFile` source even when its path is omitted and resolved to the
                 // default path. Only the synthesized fallback `default` root (added when no such
                 // entry exists in config at all) uses `ImplicitDefault` source.
-                let source = AppParamSource::ConfigurationFile;
-                let value = RootContext::from_config(root_config, app_dirs);
-                (root_config.name.clone(), AppParam::new(source, value))
+                let source = AppParamSource::ConfigurationFile {
+                    path: config_path.clone(),
+                };
+                let value = RootContext::from_config(&source, config, app_dirs);
+                (config.name.clone(), AppParam::new(source, value))
             })
             .collect();
 
         map.entry(DEFAULT_ROOT_NAME.to_owned()).or_insert_with(|| {
             let source = AppParamSource::ImplicitDefault;
-            let value = RootContext::from_config(&RootConfig::default_root(), app_dirs);
+            let value = RootContext::from_config(&source, &RootConfig::default_root(), app_dirs);
             AppParam::new(source, value)
         });
 
@@ -71,7 +77,7 @@ impl RootContextMap {
 
 fn default_path(app_dirs: &AppDirs) -> PrettyPath {
     UnresolvedPath::new(app_dirs.data_local_dir().join("root"))
-        .normalize_with_home(app_dirs.home_dir())
+        .normalize(&AppParamSource::ImplicitDefault, app_dirs)
 }
 
 #[derive(Debug, Clone)]
@@ -83,17 +89,17 @@ pub(in crate::presentation) struct RootContext {
 }
 
 impl RootContext {
-    fn from_config(root_config: &RootConfig, app_dirs: &AppDirs) -> Self {
-        let path = root_config
+    fn from_config(source: &AppParamSource, config: &RootConfig, app_dirs: &AppDirs) -> Self {
+        let path = config
             .path
             .clone()
-            .map(|path| path.normalize_with_home(app_dirs.home_dir()))
+            .map(|path| path.normalize(source, app_dirs))
             .unwrap_or_else(|| default_path(app_dirs));
         Self {
-            root: Root::new(root_config.name.clone(), path),
-            visit_hidden_dirs: root_config.visit_hidden_dirs,
-            visit_repo_subdirs: root_config.visit_repo_subdirs,
-            include_bare_repo: root_config.include_bare_repo,
+            root: Root::new(config.name.clone(), path),
+            visit_hidden_dirs: config.visit_hidden_dirs,
+            visit_repo_subdirs: config.visit_repo_subdirs,
+            include_bare_repo: config.include_bare_repo,
         }
     }
 
@@ -125,6 +131,8 @@ impl RootContext {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use tempfile::TempDir;
 
     use crate::{domain::model::path_like::PathLike as _, presentation::config::Config};
@@ -134,10 +142,15 @@ mod tests {
     #[test]
     fn default_config_resolves_default_root_from_injected_app_dirs() {
         let home = TempDir::new().unwrap();
-        let app_dirs = AppDirs::new_for_test(env!("CARGO_BIN_NAME"), home.path()).unwrap();
+        let app_dirs =
+            AppDirs::new_for_test(env!("CARGO_BIN_NAME"), home.path(), home.path()).unwrap();
+        let config_path = PrettyPath::from_pair(
+            home.path().join("config.toml"),
+            PathBuf::from("~/config.toml"),
+        );
         let config = Config::default();
 
-        let root_ctx = RootContextMap::new(&config.roots, &app_dirs);
+        let root_ctx = RootContextMap::new(&config_path, &config.roots, &app_dirs);
 
         let default_root = root_ctx.default_root();
         assert_eq!(default_root.value().name(), "default");
@@ -150,30 +163,43 @@ mod tests {
     #[test]
     fn configuration_file_default_root_overrides_injected_default_root_path() {
         let home = TempDir::new().unwrap();
-        let app_dirs = AppDirs::new_for_test(env!("CARGO_BIN_NAME"), home.path()).unwrap();
-        let config: Config = toml_edit::de::from_str(
+        let app_dirs =
+            AppDirs::new_for_test(env!("CARGO_BIN_NAME"), home.path(), home.path()).unwrap();
+        let config_path = PrettyPath::from_pair(
+            home.path().join("config.toml"),
+            PathBuf::from("~/config.toml"),
+        );
+        let custom_root = if cfg!(windows) {
+            std::path::PathBuf::from(r"C:\tmp\custom-root")
+        } else {
+            std::path::PathBuf::from("/tmp/custom-root")
+        };
+        let config: Config = toml_edit::de::from_str(&format!(
             r#"
             [[root]]
             name = "default"
-            path = "/tmp/custom-root"
+            path = '{}'
             "#,
-        )
+            custom_root.display()
+        ))
         .unwrap();
 
-        let root_ctx = RootContextMap::new(&config.roots, &app_dirs);
+        let root_ctx = RootContextMap::new(&config_path, &config.roots, &app_dirs);
 
         let default_root = root_ctx.default_root();
         assert_eq!(default_root.value().name(), "default");
-        assert_eq!(
-            default_root.value().path().as_real_path(),
-            std::path::Path::new("/tmp/custom-root")
-        );
+        assert_eq!(default_root.value().path().as_real_path(), &custom_root);
     }
 
     #[test]
     fn configuration_file_root_entry_with_omitted_path_remains_configuration_file() {
         let home = TempDir::new().unwrap();
-        let app_dirs = AppDirs::new_for_test(env!("CARGO_BIN_NAME"), home.path()).unwrap();
+        let app_dirs =
+            AppDirs::new_for_test(env!("CARGO_BIN_NAME"), home.path(), home.path()).unwrap();
+        let config_path = PrettyPath::from_pair(
+            home.path().join("config.toml"),
+            PathBuf::from("~/config.toml"),
+        );
         let config: Config = toml_edit::de::from_str(
             r#"
             [[root]]
@@ -182,7 +208,7 @@ mod tests {
         )
         .unwrap();
 
-        let root_ctx = RootContextMap::new(&config.roots, &app_dirs);
+        let root_ctx = RootContextMap::new(&config_path, &config.roots, &app_dirs);
 
         let foo_root = root_ctx.root_by_name("foo").unwrap();
         assert_eq!(foo_root.value().name(), "foo");

--- a/src/presentation/model/app_param.rs
+++ b/src/presentation/model/app_param.rs
@@ -1,5 +1,7 @@
+use crate::domain::model::pretty_path::PrettyPath;
+
 /// Source of an application input parameter.
-#[derive(Debug, Clone, PartialEq, Eq, derive_more::IsVariant)]
+#[derive(Debug, Clone, derive_more::IsVariant)]
 pub(in crate::presentation) enum AppParamSource {
     /// Value provided through a clap argument source.
     ///
@@ -7,7 +9,7 @@ pub(in crate::presentation) enum AppParamSource {
     /// or by the environment variable bound to that option via clap `env`.
     CommandLineArgument,
     /// Value loaded from a configuration file.
-    ConfigurationFile,
+    ConfigurationFile { path: PrettyPath },
     /// Value synthesized by the application when the user did not provide one.
     ImplicitDefault,
 }
@@ -38,6 +40,13 @@ impl<T> AppParam<T> {
         AppParam {
             source: self.source,
             value: f(self.value),
+        }
+    }
+
+    pub(crate) fn as_ref(&self) -> AppParam<&T> {
+        AppParam {
+            source: self.source.clone(),
+            value: &self.value,
         }
     }
 }

--- a/src/presentation/model/unresolved_path.rs
+++ b/src/presentation/model/unresolved_path.rs
@@ -6,7 +6,11 @@ use std::{
 
 use serde::Deserialize;
 
-use crate::domain::model::pretty_path::PrettyPath;
+use crate::{
+    app_dirs::AppDirs,
+    domain::model::{path_like::PathLike, pretty_path::PrettyPath},
+    presentation::model::app_param::AppParamSource,
+};
 
 #[derive(Debug, Default, Clone, Deserialize)]
 #[serde(transparent)]
@@ -48,16 +52,38 @@ impl UnresolvedPath {
         Self(path)
     }
 
-    pub(in crate::presentation) fn normalize_with_home<P>(&self, home: &P) -> PrettyPath
-    where
-        P: AsRef<Path> + ?Sized,
-    {
-        let home = home.as_ref();
-        let resolved_path = match self.0.strip_prefix("~") {
-            Ok(rest) => home.join(rest),
+    pub(in crate::presentation) fn normalize(
+        &self,
+        source: &AppParamSource,
+        app_dirs: &AppDirs,
+    ) -> PrettyPath {
+        let home_dir = app_dirs.home_dir();
+        let mut resolved_path = match self.0.strip_prefix("~") {
+            Ok(rest) => home_dir.join(rest),
             Err(_) => self.0.clone(),
         };
-        let display_path = match resolved_path.strip_prefix(home) {
+
+        if resolved_path.is_relative() {
+            match source {
+                AppParamSource::CommandLineArgument => {
+                    resolved_path = app_dirs.working_dir().join(resolved_path);
+                }
+                AppParamSource::ConfigurationFile { path } => {
+                    let config_dir = path.as_real_path().parent().unwrap();
+                    assert!(config_dir.is_absolute());
+                    resolved_path = config_dir.join(resolved_path);
+                }
+                AppParamSource::ImplicitDefault => {
+                    // default path values should never be relative, so this is likely a bug
+                    panic!(
+                        "Unexpected relative path from implicit default source: {:?}",
+                        self.0
+                    )
+                }
+            }
+        }
+
+        let display_path = match resolved_path.strip_prefix(home_dir) {
             Ok(rest) => Path::new("~").join(rest),
             Err(_) => resolved_path.clone(),
         };
@@ -78,57 +104,112 @@ impl FromStr for UnresolvedPath {
 
 #[cfg(test)]
 mod tests {
+
     use crate::domain::model::path_like::PathLike as _;
 
     use super::*;
 
     #[test]
-    fn expand() {
-        let home = Path::new("/home/foo");
+    fn normalize_tilde_and_home_paths() {
+        let app_dirs = AppDirs::new_for_test(env!("CARGO_BIN_NAME"), "/home/foo", "/work").unwrap();
+        let home_dir = app_dirs.home_dir();
+        let config_dir = UnresolvedPath::new(app_dirs.config_dir().to_owned())
+            .normalize(&AppParamSource::ImplicitDefault, &app_dirs);
+        let config_path = PrettyPath::from_pair(
+            config_dir.as_real_path().join("config.toml"),
+            config_dir.as_display_path().join("config.toml"),
+        );
+        let source = AppParamSource::ConfigurationFile { path: config_path };
 
         // expand first tilde component
-        let path = UnresolvedPath::new("~/.config/souko".into()).normalize_with_home(home);
-        assert_eq!(path.as_display_path(), Path::new("~").join(".config/souko"));
-        assert_eq!(path.as_real_path(), home.join(".config/souko"));
+        let path = UnresolvedPath::new("~/.config/souko".into()).normalize(&source, &app_dirs);
+        assert_eq!(path.as_display_path(), Path::new("~/.config/souko"));
+        assert_eq!(path.as_real_path(), home_dir.join(".config/souko"));
 
         // expand bare tilde to home
-        let path = UnresolvedPath::new("~".into()).normalize_with_home(home);
+        let path = UnresolvedPath::new("~".into()).normalize(&source, &app_dirs);
         assert_eq!(path.as_display_path(), Path::new("~"));
-        assert_eq!(path.as_real_path(), home);
+        assert_eq!(path.as_real_path(), home_dir);
 
         // normalize bare tilde with trailing separator to base tilde
-        let path = UnresolvedPath::new("~/".into()).normalize_with_home(home);
+        let path = UnresolvedPath::new("~/".into()).normalize(&source, &app_dirs);
         assert_eq!(path.as_display_path(), Path::new("~"));
-        assert_eq!(path.as_real_path(), home);
+        assert_eq!(path.as_real_path(), home_dir);
 
-        // don't expand tilde+username component
-        let path = UnresolvedPath::new("~foo/.config/souko".into()).normalize_with_home(home);
-        assert_eq!(path.as_display_path(), Path::new("~foo/.config/souko"));
-        assert_eq!(path.as_real_path(), Path::new("~foo/.config/souko"));
+        // don't expand tilde+username component; it is treated as a relative path
+        let path = UnresolvedPath::new("~foo/.config/souko".into()).normalize(&source, &app_dirs);
+        assert_eq!(
+            path.as_display_path(),
+            config_dir.as_display_path().join("~foo/.config/souko")
+        );
+        assert_eq!(
+            path.as_real_path(),
+            config_dir.as_real_path().join("~foo/.config/souko")
+        );
 
         // don't expand non-first tilde component
-        let path = UnresolvedPath::new("/foo/~/baz".into()).normalize_with_home(home);
-        assert_eq!(path.as_display_path(), Path::new("/foo/~/baz"));
-        assert_eq!(path.as_real_path(), Path::new("/foo/~/baz"));
+        let absolute_path = home_dir.parent().unwrap().join("~/baz");
+        let path = UnresolvedPath::new(absolute_path.clone()).normalize(&source, &app_dirs);
+        assert_eq!(path.as_display_path(), absolute_path);
+        assert_eq!(path.as_real_path(), absolute_path);
 
         // normalize home itself to base tilde
-        let path = UnresolvedPath::new("/home/foo".into()).normalize_with_home(home);
+        let path = UnresolvedPath::new(home_dir.to_owned()).normalize(&source, &app_dirs);
         assert_eq!(path.as_display_path(), Path::new("~"));
-        assert_eq!(path.as_real_path(), home);
+        assert_eq!(path.as_real_path(), home_dir);
 
         // normalize home itself with trailing separator to base tilde
-        let path = UnresolvedPath::new("/home/foo/".into()).normalize_with_home(home);
+        let path = UnresolvedPath::new(format!("{}/", home_dir.display()).into())
+            .normalize(&source, &app_dirs);
         assert_eq!(path.as_display_path(), Path::new("~"));
-        assert_eq!(path.as_real_path(), home);
+        assert_eq!(path.as_real_path(), home_dir);
 
         // don't normalize paths that only share a string prefix with home
-        let path = UnresolvedPath::new("/home/foobar/bar".into()).normalize_with_home(home);
-        assert_eq!(path.as_display_path(), Path::new("/home/foobar/bar"));
-        assert_eq!(path.as_real_path(), Path::new("/home/foobar/bar"));
+        let sibling_of_home_dir = home_dir.parent().unwrap().join("foobar");
+        let path = UnresolvedPath::new(sibling_of_home_dir.clone()).normalize(&source, &app_dirs);
+        assert_eq!(path.as_display_path(), sibling_of_home_dir);
+        assert_eq!(path.as_real_path(), sibling_of_home_dir);
 
         // normalize a path under home to a tilde-based display path
-        let path = UnresolvedPath::new("/home/foo/bar".into()).normalize_with_home(home);
-        assert_eq!(path.as_display_path(), Path::new("~").join("bar"));
-        assert_eq!(path.as_real_path(), Path::new("/home/foo/bar"));
+        let path = UnresolvedPath::new(home_dir.join("bar")).normalize(&source, &app_dirs);
+        assert_eq!(path.as_display_path(), Path::new("~/bar"));
+        assert_eq!(path.as_real_path(), home_dir.join("bar"));
+    }
+
+    #[test]
+    fn normalize_resolves_relative_paths_from_configuration_file_directory() {
+        let app_dirs = AppDirs::new_for_test(env!("CARGO_BIN_NAME"), "/home/foo", "/work").unwrap();
+        let config_dir = UnresolvedPath::new(app_dirs.config_dir().join("nested"))
+            .normalize(&AppParamSource::ImplicitDefault, &app_dirs);
+        let config_path = PrettyPath::from_pair(
+            config_dir.as_real_path().join("config.toml"),
+            config_dir.as_display_path().join("config.toml"),
+        );
+        let source = AppParamSource::ConfigurationFile { path: config_path };
+
+        let path = UnresolvedPath::new("repos/root".into()).normalize(&source, &app_dirs);
+
+        assert_eq!(
+            path.as_real_path(),
+            config_dir.as_real_path().join("repos/root"),
+        );
+        assert_eq!(
+            path.as_display_path(),
+            config_dir.as_display_path().join("repos/root"),
+        );
+    }
+
+    #[test]
+    fn normalize_resolves_relative_paths_from_command_line_working_directory() {
+        let app_dirs = AppDirs::new_for_test(env!("CARGO_BIN_NAME"), "/home/foo", "/work").unwrap();
+        let source = AppParamSource::CommandLineArgument;
+
+        let path = UnresolvedPath::new("repos/cache.json".into()).normalize(&source, &app_dirs);
+
+        let expected_real_path = app_dirs.working_dir().join("repos/cache.json");
+        let expected_display_path = expected_real_path.clone();
+
+        assert_eq!(path.as_real_path(), expected_real_path);
+        assert_eq!(path.as_display_path(), expected_display_path);
     }
 }

--- a/tests/list_root_options.rs
+++ b/tests/list_root_options.rs
@@ -157,3 +157,39 @@ visit_repo_subdirs = true
         .stdout(predicate::str::contains(parent_repo.display().to_string()))
         .stdout(predicate::str::contains(child_repo.display().to_string()));
 }
+
+#[test]
+fn list_resolves_root_path_relative_to_configuration_file_directory() {
+    let home = TempDir::new().unwrap();
+
+    let config_root = home.child("config-root");
+    let config_dir = config_root.child("nested");
+    config_dir.create_dir_all().unwrap();
+
+    let repo = config_root.child("repos/example");
+    repo.create_dir_all().unwrap();
+    git2::Repository::init(repo.path()).unwrap();
+
+    config_dir
+        .child("config.toml")
+        .write_str(
+            r#"
+[[root]]
+name = "default"
+path = "../repos"
+"#,
+        )
+        .unwrap();
+
+    let repo = canonical(repo.path());
+
+    common::souko_cmd(home.path())
+        .args([
+            "--config",
+            config_dir.child("config.toml").path().to_str().unwrap(),
+            "list",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(repo.display().to_string()));
+}


### PR DESCRIPTION
Closes #676

## Summary
- resolve relative paths from configuration files against the directory containing the config file
- resolve relative paths from CLI arguments against the current working directory
- add unit and integration tests covering config-relative and CLI-relative path resolution

## Details
This change updates path normalization so that relative paths are interpreted according to where they come from.

Configuration file values now carry the path of the config file that provided them, allowing `root.path` entries to be resolved relative to that file's directory. Command-line values such as `--config` and `--repo-cache` are resolved relative to the current working directory.

The change also keeps implicit default paths absolute, preserves existing `~` display normalization, and adds tests for:

- tilde and home-path normalization
- relative paths from configuration files
- relative paths from command-line arguments
- `list` using a `root.path` that is relative to the selected config file

## Testing
- `cargo test`