### PR TITLE
chore: replace once_cell with std LazyLock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1577,7 +1577,6 @@ dependencies = [
  "dunce",
  "git2",
  "git2_credentials",
- "once_cell",
  "predicates",
  "regex",
  "remove_dir_all",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ directories = "6.0.0"
 dunce = "1.0.5"
 git2 = { version = "0.20.4" }
 git2_credentials = "0.15.0"
-once_cell = "1.21.4"
 regex = "1.12.3"
 remove_dir_all = "1.0.0"
 serde = { version = "1.0.228", features = ["derive"] }
@@ -64,8 +63,6 @@ predicates = "3.1.4"
 default = []
 vendored-libgit2 = ["git2/vendored-libgit2"]
 vendored-openssl = ["git2/vendored-openssl"]
-
-[profile.dev]
 
 [profile.release]
 strip = true

--- a/src/domain/model/scheme.rs
+++ b/src/domain/model/scheme.rs
@@ -2,9 +2,9 @@ use std::{
     borrow::Borrow,
     fmt::{self, Display},
     str::FromStr,
+    sync::LazyLock,
 };
 
-use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::Deserialize;
 use thiserror::Error;
@@ -35,8 +35,8 @@ impl FromStr for Scheme {
     type Err = ParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        static SCHEME_RE: Lazy<Regex> =
-            Lazy::new(|| Regex::new(r"^[a-zA-Z][a-zA-Z0-9+.-]+$").unwrap());
+        static SCHEME_RE: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new(r"^[a-zA-Z][a-zA-Z0-9+.-]+$").unwrap());
         if !SCHEME_RE.is_match(s) {
             return Err(ParseError::InvalidScheme {
                 scheme: s.to_string(),

--- a/src/domain/model/template.rs
+++ b/src/domain/model/template.rs
@@ -3,9 +3,9 @@ use std::{
     collections::HashMap,
     fmt::{self, Display, Write},
     str::FromStr,
+    sync::LazyLock,
 };
 
-use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -181,8 +181,8 @@ fn push_str(parts: &mut Vec<Parts>, s: &str) {
 }
 
 fn is_valid_variable(s: &str) -> bool {
-    static VARIABLE_RE: Lazy<Regex> =
-        Lazy::new(|| Regex::new(r"^[a-zA-Z_][a-zA-Z0-9_]*$").unwrap());
+    static VARIABLE_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"^[a-zA-Z_][a-zA-Z0-9_]*$").unwrap());
     VARIABLE_RE.is_match(s)
 }
 


### PR DESCRIPTION
## Summary
- replace `once_cell::sync::Lazy` with `std::sync::LazyLock`
- remove the direct `once_cell` dependency from `Cargo.toml`
- refresh `Cargo.lock` accordingly

## Verification
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`