### PR TITLE
Rename PrettyPath to PathBufPair

### DIFF
--- a/src/application/usecase/list.rs
+++ b/src/application/usecase/list.rs
@@ -6,8 +6,8 @@ use color_eyre::eyre::eyre;
 use crate::{
     domain::{
         model::{
+            path_buf_pair::PathBufPair,
             path_like::PathLike,
-            pretty_path::PrettyPath,
             repo::CanonicalRepo,
             root::{CanonicalRoot, Root},
         },
@@ -37,7 +37,7 @@ impl Default for ListOptions {
 #[derive(Debug, Clone)]
 pub(crate) struct ListContext {
     pub(crate) now: DateTime<Utc>,
-    pub(crate) repo_cache_path: PrettyPath,
+    pub(crate) repo_cache_path: PathBufPair,
 }
 
 #[derive(Debug)]
@@ -52,7 +52,7 @@ pub(crate) struct ListRootInput {
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum ListUsecaseError {
     #[error("root `{name}` does not exist: {}", path.display())]
-    RootNotExist { name: String, path: PrettyPath },
+    RootNotExist { name: String, path: PathBufPair },
     #[error("failed to get canonical path of root `{name}`")]
     CanonicalizeRoot {
         name: String,

--- a/src/cli/command/list.rs
+++ b/src/cli/command/list.rs
@@ -7,7 +7,7 @@ use crate::{
         context::{global::GlobalContext, list::ListContext},
         message, render,
     },
-    domain::model::pretty_path::PrettyPath,
+    domain::model::path_buf_pair::PathBufPair,
     util::error::FormatErrorChain as _,
 };
 
@@ -27,7 +27,7 @@ pub(in crate::cli) fn dispatch(global_ctx: &GlobalContext, list_ctx: &ListContex
 
     let context = ListUsecaseContext {
         now: Utc::now(),
-        repo_cache_path: PrettyPath::new(global_ctx.repo_cache_path()),
+        repo_cache_path: PathBufPair::new(global_ctx.repo_cache_path()),
     };
     let options = ListOptions::default();
 

--- a/src/cli/context/global.rs
+++ b/src/cli/context/global.rs
@@ -9,7 +9,7 @@ use crate::{
         context::{query::QueryContext, root::RootContextMap},
         input::app_param::AppParam,
     },
-    domain::model::{path_like::PathLike as _, pretty_path::PrettyPath},
+    domain::model::{path_buf_pair::PathBufPair, path_like::PathLike as _},
     util::file,
 };
 
@@ -18,7 +18,7 @@ pub(in crate::cli) struct GlobalContext {
     usecases: Usecases,
     root_map: RootContextMap,
     query: QueryContext,
-    repo_cache_path: PrettyPath,
+    repo_cache_path: PathBufPair,
 }
 
 impl GlobalContext {
@@ -46,7 +46,7 @@ impl GlobalContext {
         &self.usecases
     }
 
-    pub(in crate::cli) fn repo_cache_path(&self) -> &PrettyPath {
+    pub(in crate::cli) fn repo_cache_path(&self) -> &PathBufPair {
         &self.repo_cache_path
     }
 
@@ -59,7 +59,7 @@ impl GlobalContext {
     }
 }
 
-fn load_config(path: &AppParam<PrettyPath>) -> Result<Config> {
+fn load_config(path: &AppParam<PathBufPair>) -> Result<Config> {
     match file::load_toml("configuration file", path.value())? {
         Some(config) => Ok(config),
         None if path.source().is_implicit_default() => Ok(Config::default()),

--- a/src/cli/context/root.rs
+++ b/src/cli/context/root.rs
@@ -11,7 +11,7 @@ use crate::{
             unresolved_path::UnresolvedPath,
         },
     },
-    domain::model::{pretty_path::PrettyPath, root::Root},
+    domain::model::{path_buf_pair::PathBufPair, root::Root},
 };
 
 #[derive(Debug)]
@@ -21,7 +21,7 @@ pub(in crate::cli) struct RootContextMap {
 
 impl RootContextMap {
     pub(in crate::cli) fn new(
-        config_path: &PrettyPath,
+        config_path: &PathBufPair,
         config: &[RootConfig],
         app_dirs: &AppDirs,
     ) -> Self {
@@ -70,7 +70,7 @@ impl RootContextMap {
     }
 }
 
-fn default_path(app_dirs: &AppDirs) -> PrettyPath {
+fn default_path(app_dirs: &AppDirs) -> PathBufPair {
     UnresolvedPath::new(app_dirs.data_local_dir().join("root"))
         .normalize(&AppParamSource::ImplicitDefault, app_dirs)
 }
@@ -107,7 +107,7 @@ impl RootContext {
         self.root.name()
     }
 
-    pub(in crate::cli) fn path(&self) -> &PrettyPath {
+    pub(in crate::cli) fn path(&self) -> &PathBufPair {
         self.root.path()
     }
 
@@ -139,7 +139,7 @@ mod tests {
         let home = TempDir::new().unwrap();
         let app_dirs =
             AppDirs::new_for_test(env!("CARGO_BIN_NAME"), home.path(), home.path()).unwrap();
-        let config_path = PrettyPath::from_pair(
+        let config_path = PathBufPair::from_pair(
             home.path().join("config.toml"),
             PathBuf::from("~/config.toml"),
         );
@@ -160,7 +160,7 @@ mod tests {
         let home = TempDir::new().unwrap();
         let app_dirs =
             AppDirs::new_for_test(env!("CARGO_BIN_NAME"), home.path(), home.path()).unwrap();
-        let config_path = PrettyPath::from_pair(
+        let config_path = PathBufPair::from_pair(
             home.path().join("config.toml"),
             PathBuf::from("~/config.toml"),
         );
@@ -191,7 +191,7 @@ mod tests {
         let home = TempDir::new().unwrap();
         let app_dirs =
             AppDirs::new_for_test(env!("CARGO_BIN_NAME"), home.path(), home.path()).unwrap();
-        let config_path = PrettyPath::from_pair(
+        let config_path = PathBufPair::from_pair(
             home.path().join("config.toml"),
             PathBuf::from("~/config.toml"),
         );

--- a/src/cli/input/app_param.rs
+++ b/src/cli/input/app_param.rs
@@ -1,4 +1,4 @@
-use crate::domain::model::pretty_path::PrettyPath;
+use crate::domain::model::path_buf_pair::PathBufPair;
 
 /// Source of an application input parameter.
 #[derive(Debug, Clone, derive_more::IsVariant)]
@@ -9,7 +9,7 @@ pub(in crate::cli) enum AppParamSource {
     /// or by the environment variable bound to that option via clap `env`.
     CommandLineArgument,
     /// Value loaded from a configuration file.
-    ConfigurationFile { path: PrettyPath },
+    ConfigurationFile { path: PathBufPair },
     /// Value synthesized by the application when the user did not provide one.
     ImplicitDefault,
 }

--- a/src/cli/input/unresolved_path.rs
+++ b/src/cli/input/unresolved_path.rs
@@ -9,7 +9,7 @@ use serde::Deserialize;
 use crate::{
     app_dirs::AppDirs,
     cli::input::app_param::AppParamSource,
-    domain::model::{path_like::PathLike, pretty_path::PrettyPath},
+    domain::model::{path_buf_pair::PathBufPair, path_like::PathLike},
 };
 
 #[derive(Debug, Default, Clone, Deserialize)]
@@ -56,7 +56,7 @@ impl UnresolvedPath {
         &self,
         source: &AppParamSource,
         app_dirs: &AppDirs,
-    ) -> PrettyPath {
+    ) -> PathBufPair {
         let home_dir = app_dirs.home_dir();
         let mut resolved_path = match self.0.strip_prefix("~") {
             Ok(rest) => home_dir.join(rest),
@@ -87,7 +87,7 @@ impl UnresolvedPath {
             Ok(rest) => Path::new("~").join(rest),
             Err(_) => resolved_path.clone(),
         };
-        PrettyPath::from_pair(
+        PathBufPair::from_pair(
             normalize_trailing_separator(&resolved_path),
             normalize_trailing_separator(&display_path),
         )
@@ -115,7 +115,7 @@ mod tests {
         let home_dir = app_dirs.home_dir();
         let config_dir = UnresolvedPath::new(app_dirs.config_dir().to_owned())
             .normalize(&AppParamSource::ImplicitDefault, &app_dirs);
-        let config_path = PrettyPath::from_pair(
+        let config_path = PathBufPair::from_pair(
             config_dir.as_real_path().join("config.toml"),
             config_dir.as_display_path().join("config.toml"),
         );
@@ -181,7 +181,7 @@ mod tests {
         let app_dirs = AppDirs::new_for_test(env!("CARGO_BIN_NAME"), "/home/foo", "/work").unwrap();
         let config_dir = UnresolvedPath::new(app_dirs.config_dir().join("nested"))
             .normalize(&AppParamSource::ImplicitDefault, &app_dirs);
-        let config_path = PrettyPath::from_pair(
+        let config_path = PathBufPair::from_pair(
             config_dir.as_real_path().join("config.toml"),
             config_dir.as_display_path().join("config.toml"),
         );

--- a/src/domain/model/mod.rs
+++ b/src/domain/model/mod.rs
@@ -1,5 +1,5 @@
+pub(crate) mod path_buf_pair;
 pub(crate) mod path_like;
-pub(crate) mod pretty_path;
 pub(crate) mod query;
 pub(crate) mod repo;
 pub(crate) mod root;

--- a/src/domain/model/path_buf_pair.rs
+++ b/src/domain/model/path_buf_pair.rs
@@ -3,12 +3,12 @@ use std::path::{Path, PathBuf};
 use super::path_like::PathLike;
 
 #[derive(Debug, Default, Clone)]
-pub(crate) struct PrettyPath {
+pub(crate) struct PathBufPair {
     real_path: PathBuf,
     display_path: PathBuf,
 }
 
-impl PrettyPath {
+impl PathBufPair {
     pub(crate) fn new<P>(path: P) -> Self
     where
         P: PathLike,
@@ -34,7 +34,7 @@ impl PrettyPath {
     }
 }
 
-impl PathLike for PrettyPath {
+impl PathLike for PathBufPair {
     fn as_display_path(&self) -> &Path {
         &self.display_path
     }

--- a/src/domain/model/repo.rs
+++ b/src/domain/model/repo.rs
@@ -1,11 +1,11 @@
 use std::path::{Path, PathBuf};
 
-use super::{pretty_path::PrettyPath, query::Query, root::Root};
+use super::{path_buf_pair::PathBufPair, query::Query, root::Root};
 
 #[derive(Debug, Clone)]
 pub(crate) struct Repo {
     relative_path: PathBuf,
-    path: PrettyPath,
+    path: PathBufPair,
     bare: bool,
 }
 
@@ -49,7 +49,7 @@ impl Repo {
         &self.relative_path
     }
 
-    pub(crate) fn path(&self) -> &PrettyPath {
+    pub(crate) fn path(&self) -> &PathBufPair {
         &self.path
     }
 
@@ -76,7 +76,7 @@ impl CanonicalRepo {
         self.inner.relative_path()
     }
 
-    pub(crate) fn path(&self) -> &PrettyPath {
+    pub(crate) fn path(&self) -> &PathBufPair {
         self.inner.path()
     }
 
@@ -102,7 +102,7 @@ mod tests {
         let root_display_path = PathBuf::from("~/test");
         let root = Root::new(
             "test".into(),
-            PrettyPath::from_pair(root_path, root_display_path),
+            PathBufPair::from_pair(root_path, root_display_path),
         );
 
         let parse_option = query::ParseOption::default();

--- a/src/domain/model/root.rs
+++ b/src/domain/model/root.rs
@@ -1,15 +1,15 @@
 use std::path::{Path, PathBuf};
 
-use super::pretty_path::PrettyPath;
+use super::path_buf_pair::PathBufPair;
 
 #[derive(Debug, Clone)]
 pub(crate) struct Root {
     name: String,
-    path: PrettyPath,
+    path: PathBufPair,
 }
 
 impl Root {
-    pub(crate) fn new(name: String, path: PrettyPath) -> Self {
+    pub(crate) fn new(name: String, path: PathBufPair) -> Self {
         Self { name, path }
     }
 
@@ -17,7 +17,7 @@ impl Root {
         self.name.as_ref()
     }
 
-    pub(crate) fn path(&self) -> &PrettyPath {
+    pub(crate) fn path(&self) -> &PathBufPair {
         &self.path
     }
 }
@@ -44,7 +44,7 @@ impl CanonicalRoot {
         self.inner.name()
     }
 
-    pub(crate) fn path(&self) -> &PrettyPath {
+    pub(crate) fn path(&self) -> &PathBufPair {
         self.inner.path()
     }
 

--- a/src/domain/port/dir_walker.rs
+++ b/src/domain/port/dir_walker.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Debug, path::Path};
 
-use crate::domain::model::{pretty_path::PrettyPath, root::CanonicalRoot};
+use crate::domain::model::{path_buf_pair::PathBufPair, root::CanonicalRoot};
 
 pub(crate) trait DirWalker: Debug {
     fn entries(
@@ -21,7 +21,7 @@ pub(crate) type FilterPredicate = Box<dyn FnMut(&dyn DirEntry) -> bool>;
 pub(crate) trait DirEntry: Debug {
     fn root(&self) -> &CanonicalRoot;
     fn relative_path(&self) -> &Path;
-    fn path(&self) -> &PrettyPath;
+    fn path(&self) -> &PathBufPair;
     fn is_hidden(&self) -> bool;
 }
 
@@ -34,7 +34,7 @@ impl DirEntry for &dyn DirEntry {
         DirEntry::relative_path(*self)
     }
 
-    fn path(&self) -> &PrettyPath {
+    fn path(&self) -> &PathBufPair {
         DirEntry::path(*self)
     }
 
@@ -52,7 +52,7 @@ impl DirEntry for Box<dyn DirEntry> {
         self.as_ref().relative_path()
     }
 
-    fn path(&self) -> &PrettyPath {
+    fn path(&self) -> &PathBufPair {
         self.as_ref().path()
     }
 

--- a/src/domain/port/path_canonicalizer.rs
+++ b/src/domain/port/path_canonicalizer.rs
@@ -1,11 +1,11 @@
 use std::{fmt::Debug, path::PathBuf};
 
-use crate::domain::model::{path_like::PathLike, pretty_path::PrettyPath};
+use crate::domain::model::{path_buf_pair::PathBufPair, path_like::PathLike};
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum PathCanonicalizerError {
     #[error("path not found: {}", path.display())]
-    PathNotFound { path: PrettyPath },
+    PathNotFound { path: PathBufPair },
     #[error(transparent)]
     Backend(#[from] Box<dyn std::error::Error>),
 }

--- a/src/domain/port/repo_probe.rs
+++ b/src/domain/port/repo_probe.rs
@@ -1,11 +1,11 @@
 use std::fmt::Debug;
 
-use crate::domain::model::{path_like::PathLike, pretty_path::PrettyPath};
+use crate::domain::model::{path_buf_pair::PathBufPair, path_like::PathLike};
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum RepoProbeError {
     #[error("not a git repository: {}", path.display())]
-    NotARepo { path: PrettyPath },
+    NotARepo { path: PathBufPair },
     #[error(transparent)]
     Backend(#[from] Box<dyn std::error::Error>),
 }

--- a/src/domain/service/repo_scan.rs
+++ b/src/domain/service/repo_scan.rs
@@ -5,7 +5,7 @@ use std::{
 
 use crate::domain::{
     model::{
-        pretty_path::PrettyPath,
+        path_buf_pair::PathBufPair,
         repo::{CanonicalRepo, Repo},
         root::CanonicalRoot,
     },
@@ -119,7 +119,7 @@ where
         self.port.relative_path()
     }
 
-    pub(crate) fn path(&self) -> &PrettyPath {
+    pub(crate) fn path(&self) -> &PathBufPair {
         self.port.path()
     }
 

--- a/src/infrastructure/fs/dir_walker.rs
+++ b/src/infrastructure/fs/dir_walker.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use crate::domain::{
-    model::{path_like::PathLike, pretty_path::PrettyPath, root::CanonicalRoot},
+    model::{path_buf_pair::PathBufPair, path_like::PathLike, root::CanonicalRoot},
     port::dir_walker::{DirEntries, DirEntry, DirWalker, FilterPredicate},
 };
 
@@ -103,7 +103,7 @@ impl Iterator for FsDirEntries {
 struct FsDirEntry {
     root: Arc<CanonicalRoot>,
     relative_path: PathBuf,
-    path: PrettyPath,
+    path: PathBufPair,
 }
 
 impl FsDirEntry {
@@ -132,7 +132,7 @@ impl DirEntry for FsDirEntry {
         &self.relative_path
     }
 
-    fn path(&self) -> &PrettyPath {
+    fn path(&self) -> &PathBufPair {
         &self.path
     }
 

--- a/src/infrastructure/fs/path_canonicalizer.rs
+++ b/src/infrastructure/fs/path_canonicalizer.rs
@@ -1,7 +1,7 @@
 use std::{io, path::PathBuf};
 
 use crate::domain::{
-    model::{path_like::PathLike, pretty_path::PrettyPath},
+    model::{path_buf_pair::PathBufPair, path_like::PathLike},
     port::path_canonicalizer::{PathCanonicalizer, PathCanonicalizerError},
 };
 
@@ -30,7 +30,7 @@ impl PathCanonicalizer for FsPathCanonicalizer {
             Ok(path) => Ok(path),
             Err(err) if err.kind() == io::ErrorKind::NotFound => {
                 Err(PathCanonicalizerError::PathNotFound {
-                    path: PrettyPath::new(path),
+                    path: PathBufPair::new(path),
                 })
             }
             Err(err) => Err(PathCanonicalizerError::Backend(

--- a/src/infrastructure/git2/repo_probe.rs
+++ b/src/infrastructure/git2/repo_probe.rs
@@ -1,5 +1,5 @@
 use crate::domain::{
-    model::{path_like::PathLike, pretty_path::PrettyPath},
+    model::{path_buf_pair::PathBufPair, path_like::PathLike},
     port::repo_probe::{RepoProbe, RepoProbeError, RepoProbeResult},
 };
 
@@ -16,7 +16,7 @@ impl Git2RepoProbe {
 enum Error {
     #[error("failed to open repository: {}", path.display())]
     Open {
-        path: PrettyPath,
+        path: PathBufPair,
         #[source]
         source: git2::Error,
     },
@@ -25,7 +25,7 @@ enum Error {
 impl RepoProbe for Git2RepoProbe {
     fn probe(&self, path: &dyn PathLike) -> Result<RepoProbeResult, RepoProbeError> {
         let repo = git2::Repository::open(path.as_real_path()).map_err(|source| {
-            let path = PrettyPath::new(path);
+            let path = PathBufPair::new(path);
             if source.code() == git2::ErrorCode::NotFound {
                 RepoProbeError::NotARepo { path }
             } else {


### PR DESCRIPTION
## Summary
- rename `PrettyPath` to `PathBufPair` across the codebase
- keep the existing real-path/display-path behavior and `PathLike` integration intact
- update related domain, CLI, and infrastructure types to use the new name

## Testing
- just ci