### PR TITLE
Make templates context-specific

### DIFF
--- a/src/cli/args/list.rs
+++ b/src/cli/args/list.rs
@@ -1,6 +1,6 @@
 use color_eyre::eyre::Result;
 
-use crate::domain::model::template::{Template, TemplateContext};
+use crate::{cli::render::list::RepoListTemplateContext, domain::model::template::Template};
 
 #[derive(Debug, Clone, Default, clap::Args)]
 pub(in crate::cli) struct ListArgs {
@@ -20,19 +20,15 @@ pub(in crate::cli) struct FormatArgs {
     json: bool,
     /// Output each repository using a template string
     #[arg(long)]
-    template: Option<Template>,
+    template: Option<Template<RepoListTemplateContext>>,
 }
 
 impl FormatArgs {
-    fn validate<C>(&self) -> Result<Format>
-    where
-        C: TemplateContext,
-    {
+    fn validate(&self) -> Result<Format> {
         let FormatArgs { json, template } = self;
         if *json {
             Ok(Format::Json)
         } else if let Some(template) = template {
-            template.validate::<C>()?;
             Ok(Format::Template(template.clone()))
         } else {
             Ok(Format::Default)
@@ -45,7 +41,7 @@ pub(in crate::cli) enum Format {
     #[default]
     Default,
     Json,
-    Template(Template),
+    Template(Template<RepoListTemplateContext>),
 }
 
 impl ListArgs {
@@ -53,10 +49,7 @@ impl ListArgs {
         self.root_name.as_deref()
     }
 
-    pub(in crate::cli) fn format<C>(&self) -> Result<Format>
-    where
-        C: TemplateContext,
-    {
-        self.format.validate::<C>()
+    pub(in crate::cli) fn format(&self) -> Result<Format> {
+        self.format.validate()
     }
 }

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -3,7 +3,9 @@ use std::{collections::HashMap, str::FromStr as _};
 use serde::Deserialize;
 
 use super::input::unresolved_path::UnresolvedPath;
-use crate::domain::model::{scheme::Scheme, template::Template};
+use crate::domain::model::{
+    query::CustomSchemeTemplateContext, scheme::Scheme, template::Template,
+};
 
 pub(in crate::cli) const DEFAULT_ROOT_NAME: &str = "default";
 
@@ -54,7 +56,8 @@ pub(in crate::cli) struct QueryConfig {
     #[serde(default)]
     pub(in crate::cli) scheme_alias: HashMap<Scheme, Scheme>,
     #[serde(default)]
-    pub(in crate::cli) custom_scheme: HashMap<Scheme, Template>,
+    pub(in crate::cli) custom_scheme:
+        HashMap<Scheme, Template<CustomSchemeTemplateContext<'static>>>,
 }
 
 impl Default for QueryConfig {

--- a/src/cli/context/list.rs
+++ b/src/cli/context/list.rs
@@ -4,7 +4,6 @@ use crate::cli::{
     args::list::{Format, ListArgs},
     context::{global::GlobalContext, root::RootContext},
     input::app_param::AppParam,
-    render::list::RepoListTemplateContext,
 };
 
 #[derive(Debug)]
@@ -23,7 +22,7 @@ impl ListContext {
                 .collect::<Result<Vec<_>>>()?,
             None => root_map.all_roots().cloned().collect(),
         };
-        let format = args.format::<RepoListTemplateContext>()?;
+        let format = args.format()?;
         Ok(Self { roots, format })
     }
 

--- a/src/cli/context/query.rs
+++ b/src/cli/context/query.rs
@@ -2,7 +2,11 @@ use std::{collections::HashMap, str::FromStr as _};
 
 use crate::{
     cli::config::QueryConfig,
-    domain::model::{query::ParseOption, scheme::Scheme, template::Template},
+    domain::model::{
+        query::{CustomSchemeTemplateContext, ParseOption},
+        scheme::Scheme,
+        template::Template,
+    },
 };
 
 #[derive(Debug)]
@@ -21,7 +25,7 @@ fn predefined_aliases() -> HashMap<Scheme, Scheme> {
         .collect()
 }
 
-fn predefined_custom_schemes() -> HashMap<Scheme, Template> {
+fn predefined_custom_schemes() -> HashMap<Scheme, Template<CustomSchemeTemplateContext<'static>>> {
     [
         ("github", "https://github.com/{path}.git"),
         ("gitlab", "https://gitlab.com/{path}.git"),

--- a/src/cli/render/list.rs
+++ b/src/cli/render/list.rs
@@ -45,7 +45,11 @@ where
     Ok(())
 }
 
-fn render_template<W, Roots, Repos>(mut out: W, roots: Roots, template: &Template) -> Result<()>
+fn render_template<W, Roots, Repos>(
+    mut out: W,
+    roots: Roots,
+    template: &Template<RepoListTemplateContext>,
+) -> Result<()>
 where
     W: io::Write,
     Roots: Iterator<Item = (CanonicalRoot, Repos)>,

--- a/src/domain/model/query.rs
+++ b/src/domain/model/query.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 use thiserror::Error;
 use url::Url;
 
-use crate::domain::model::template::{TemplateContext, TemplateValidateError};
+use crate::domain::model::template::TemplateContext;
 
 use super::{scheme::Scheme, template::Template};
 
@@ -32,13 +32,6 @@ pub(crate) enum ParseError {
     },
     #[error("invalid option: circular alias {}", ErrorDisplayHelper { original_query, expanded_query })]
     CircularAlias {
-        original_query: String,
-        expanded_query: String,
-    },
-    #[error("template validation error in custom scheme {}", ErrorDisplayHelper { original_query, expanded_query })]
-    TemplateValidation {
-        #[source]
-        source: TemplateValidateError,
         original_query: String,
         expanded_query: String,
     },
@@ -68,11 +61,11 @@ impl Display for ErrorDisplayHelper<'_> {
 pub(crate) struct ParseOption {
     pub(crate) default_scheme: Option<Scheme>,
     pub(crate) scheme_alias: HashMap<Scheme, Scheme>,
-    pub(crate) custom_scheme: HashMap<Scheme, Template>,
+    pub(crate) custom_scheme: HashMap<Scheme, Template<CustomSchemeTemplateContext<'static>>>,
 }
 
 #[derive(Debug, Default, Serialize)]
-struct CustomSchemeTemplateContext<'a> {
+pub(crate) struct CustomSchemeTemplateContext<'a> {
     path: &'a str,
 }
 
@@ -141,13 +134,7 @@ impl Query {
                 // custom scheme
                 if let Some(template) = option.custom_scheme.get(scheme) {
                     let context = CustomSchemeTemplateContext::new(rest);
-                    query = template.validate_and_expand(&context).map_err(|source| {
-                        ParseError::TemplateValidation {
-                            source,
-                            original_query: original_query.clone(),
-                            expanded_query: query,
-                        }
-                    })?;
+                    query = template.expand(&context);
                     continue;
                 }
 
@@ -273,30 +260,5 @@ mod tests {
             err.to_string(),
             "invalid option: circular alias `d4:test` (expanded to `d4:xytest`)"
         );
-    }
-
-    #[test]
-    fn test_parse_with_invalid_custom_scheme_template() {
-        let option = ParseOption {
-            default_scheme: None,
-            scheme_alias: HashMap::new(),
-            custom_scheme: HashMap::from_iter([(
-                "github".parse().unwrap(),
-                "https://github.com/{owner}/{repo}.git".parse().unwrap(),
-            )]),
-        };
-
-        let err = Query::parse("github:gifnksm/souko", &option).unwrap_err();
-        assert_eq!(
-            err.to_string(),
-            "template validation error in custom scheme `github:gifnksm/souko`"
-        );
-        assert!(matches!(
-            err,
-            ParseError::TemplateValidation {
-                source: TemplateValidateError::UnknownTemplateVariable(s),
-                ..
-            } if s == "owner"
-        ));
     }
 }

--- a/src/domain/model/template.rs
+++ b/src/domain/model/template.rs
@@ -2,61 +2,45 @@ use std::{
     any,
     collections::HashMap,
     fmt::{self, Display, Write},
+    marker::PhantomData,
     str::FromStr,
-    sync::LazyLock,
 };
 
-use regex::Regex;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use thiserror::Error;
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Deserialize)]
 #[serde(try_from = "String")]
-pub(crate) struct Template {
+#[serde(bound = "C: TemplateContext")]
+pub(crate) struct Template<C> {
     parts: Vec<Parts>,
+    _context: PhantomData<C>,
 }
 
-#[derive(Debug, Error)]
-pub(crate) enum TemplateValidateError {
-    #[error("unknown template variable: {0:?}")]
-    UnknownTemplateVariable(String),
-}
-
-impl Template {
-    pub(crate) fn validate_and_expand<C>(
-        &self,
-        context: &C,
-    ) -> Result<String, TemplateValidateError>
-    where
-        C: TemplateContext,
-    {
-        self.validate::<C>()?;
-        Ok(self.expand(context))
+impl<C> fmt::Debug for Template<C> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Template")
+            .field("parts", &self.parts)
+            .field("_context", &self._context)
+            .finish()
     }
+}
 
-    pub(crate) fn validate<C>(&self) -> Result<(), TemplateValidateError>
-    where
-        C: TemplateContext,
-    {
-        let valid_variables = C::default().to_hashmap();
-        for part in &self.parts {
-            match part {
-                Parts::Text(_) => {}
-                Parts::Variable(name) => {
-                    if !valid_variables.contains_key(name) {
-                        return Err(TemplateValidateError::UnknownTemplateVariable(name.clone()));
-                    }
-                }
-            }
+impl<C> Clone for Template<C> {
+    fn clone(&self) -> Self {
+        Self {
+            parts: self.parts.clone(),
+            _context: PhantomData,
         }
-        Ok(())
     }
+}
 
-    pub(crate) fn expand<C>(&self, context: &C) -> String
-    where
-        C: TemplateContext,
-    {
+impl<C> Template<C>
+where
+    C: TemplateContext,
+{
+    pub(crate) fn expand(&self, context: &C) -> String {
         let mut result = String::new();
         let variables = context.to_hashmap();
         for part in &self.parts {
@@ -112,19 +96,23 @@ impl Parts {
 }
 
 #[derive(Debug, Error)]
-pub(crate) enum ParseError {
+pub(crate) enum TemplateParseError {
     #[error("unexpected character: {0:?}")]
     UnexpectedChar(char),
     #[error("no closing brace '}}' found")]
     NoClosingBrace,
-    #[error("invalid variable: {0}")]
-    InvalidVariable(String),
+    #[error("unknown template variable: {0}")]
+    UnknownVariable(String),
 }
 
-impl FromStr for Template {
-    type Err = ParseError;
+impl<C> FromStr for Template<C>
+where
+    C: TemplateContext,
+{
+    type Err = TemplateParseError;
 
     fn from_str(mut s: &str) -> Result<Self, Self::Err> {
+        let valid_variables = C::default().to_hashmap();
         let mut parts = vec![];
 
         while let Some(idx) = s.find(['{', '}']) {
@@ -142,22 +130,25 @@ impl FromStr for Template {
                 continue;
             }
             if s.starts_with('}') {
-                return Err(ParseError::UnexpectedChar('}'));
+                return Err(TemplateParseError::UnexpectedChar('}'));
             }
             assert!(s.starts_with('{'));
             if let Some(end) = s.find('}') {
                 let variable = s[1..end].trim();
-                if !is_valid_variable(variable) {
-                    return Err(ParseError::InvalidVariable(variable.to_string()));
+                if !valid_variables.contains_key(variable) {
+                    return Err(TemplateParseError::UnknownVariable(variable.to_string()));
                 }
                 s = &s[end + 1..];
                 parts.push(Parts::variable(variable));
             } else {
-                return Err(ParseError::NoClosingBrace);
+                return Err(TemplateParseError::NoClosingBrace);
             }
         }
         push_str(&mut parts, s);
-        Ok(Self { parts })
+        Ok(Self {
+            parts,
+            _context: PhantomData,
+        })
     }
 }
 
@@ -180,22 +171,22 @@ fn push_str(parts: &mut Vec<Parts>, s: &str) {
     }
 }
 
-fn is_valid_variable(s: &str) -> bool {
-    static VARIABLE_RE: LazyLock<Regex> =
-        LazyLock::new(|| Regex::new(r"^[a-zA-Z_][a-zA-Z0-9_]*$").unwrap());
-    VARIABLE_RE.is_match(s)
-}
-
-impl TryFrom<String> for Template {
-    type Error = ParseError;
+impl<C> TryFrom<String> for Template<C>
+where
+    C: TemplateContext,
+{
+    type Error = TemplateParseError;
 
     fn try_from(s: String) -> Result<Self, Self::Error> {
         Self::from_str(s.as_str())
     }
 }
 
-impl TryFrom<&str> for Template {
-    type Error = ParseError;
+impl<C> TryFrom<&str> for Template<C>
+where
+    C: TemplateContext,
+{
+    type Error = TemplateParseError;
 
     fn try_from(s: &str) -> Result<Self, Self::Error> {
         Self::from_str(s)
@@ -225,20 +216,6 @@ mod tests {
 
     impl TemplateContext for TestTemplateContext {}
 
-    #[test]
-    fn test_is_valid_variable() {
-        assert!(is_valid_variable("foo123"));
-        assert!(is_valid_variable("foo_bar"));
-        assert!(is_valid_variable("foo_bar_baz"));
-        assert!(is_valid_variable("a"));
-        assert!(is_valid_variable("_"));
-        assert!(!is_valid_variable(""));
-        assert!(!is_valid_variable("foo bar"));
-        assert!(!is_valid_variable("foo-bar"));
-        assert!(!is_valid_variable("foo_bar-baz"));
-        assert!(!is_valid_variable("123foo"));
-    }
-
     fn t(s: impl Display) -> Parts {
         Parts::text(s)
     }
@@ -246,25 +223,43 @@ mod tests {
         Parts::variable(s)
     }
 
+    #[derive(Debug, Default, Serialize)]
+    struct Context {
+        var: String,
+        var2: String,
+    }
+
+    impl TemplateContext for Context {}
+
     #[test]
     fn test_from_str_ok() {
-        assert_eq!(Template::from_str("foo").unwrap().parts, vec![t("foo")]);
-        assert_eq!(Template::from_str("").unwrap().parts, vec![]);
-        assert_eq!(Template::from_str("{var}").unwrap().parts, vec![v("var")]);
         assert_eq!(
-            Template::from_str("{ var2 }").unwrap().parts,
+            Template::<Context>::from_str("foo").unwrap().parts,
+            vec![t("foo")]
+        );
+        assert_eq!(Template::<Context>::from_str("").unwrap().parts, vec![]);
+        assert_eq!(
+            Template::<Context>::from_str("{var}").unwrap().parts,
+            vec![v("var")]
+        );
+        assert_eq!(
+            Template::<Context>::from_str("{ var2 }").unwrap().parts,
             vec![v("var2")]
         );
         assert_eq!(
-            Template::from_str("xxx#$%%{{)*)_*}}").unwrap().parts,
+            Template::<Context>::from_str("xxx#$%%{{)*)_*}}")
+                .unwrap()
+                .parts,
             vec![t("xxx#$%%{)*)_*}")]
         );
         assert_eq!(
-            Template::from_str("{{{var}}}").unwrap().parts,
+            Template::<Context>::from_str("{{{var}}}").unwrap().parts,
             vec![t("{"), v("var"), t("}")]
         );
         assert_eq!(
-            Template::from_str("{{{var}}} }}{var}{{").unwrap().parts,
+            Template::<Context>::from_str("{{{var}}} }}{var}{{")
+                .unwrap()
+                .parts,
             vec![t("{"), v("var"), t("} }"), v("var"), t("{")]
         );
     }
@@ -272,39 +267,34 @@ mod tests {
     #[test]
     fn test_from_str_err() {
         assert!(matches!(
-            Template::from_str("{var").unwrap_err(),
-            ParseError::NoClosingBrace
+            Template::<Context>::from_str("{var").unwrap_err(),
+            TemplateParseError::NoClosingBrace
         ));
         assert!(matches!(
-            Template::from_str("{{var}").unwrap_err(),
-            ParseError::UnexpectedChar('}')
+            Template::<Context>::from_str("{{var}").unwrap_err(),
+            TemplateParseError::UnexpectedChar('}')
         ));
         assert!(matches!(
-            Template::from_str("{2var}").unwrap_err(),
-            ParseError::InvalidVariable(s) if s == "2var"
+            Template::<Context>::from_str("{2var}").unwrap_err(),
+            TemplateParseError::UnknownVariable(s) if s == "2var"
         ));
         assert!(matches!(
-            Template::from_str("{v ar}").unwrap_err(),
-            ParseError::InvalidVariable(s) if s == "v ar"
+            Template::<Context>::from_str("{v ar}").unwrap_err(),
+            TemplateParseError::UnknownVariable(s) if s == "v ar"
         ));
     }
 
     #[test]
     fn test_validate_ok() {
-        let temp = Template::from_str("I like {food} very much").unwrap();
-        assert!(temp.validate::<TestTemplateContext>().is_ok());
-
-        let temp = Template::from_str("{food} {frequency} {drink}").unwrap();
-        assert!(temp.validate::<TestTemplateContext>().is_ok());
+        Template::<TestTemplateContext>::from_str("I like {food} very much").unwrap();
+        Template::<TestTemplateContext>::from_str("{food} {frequency} {drink}").unwrap();
     }
 
     #[test]
     fn test_validate_err_unknown_template_variable() {
-        let temp = Template::from_str("I like {food} and {dessert}").unwrap();
-        let err = temp.validate::<TestTemplateContext>().unwrap_err();
         assert!(matches!(
-            err,
-            TemplateValidateError::UnknownTemplateVariable(s) if s == "dessert"
+            Template::<TestTemplateContext>::from_str("I like {food} and {dessert}").unwrap_err(),
+            TemplateParseError::UnknownVariable(s) if s == "dessert"
         ));
     }
 
@@ -312,8 +302,7 @@ mod tests {
     fn test_validate_and_expand() {
         let temp = Template::from_str("{food} {frequency}").unwrap();
         assert_eq!(
-            temp.validate_and_expand(&TestTemplateContext::new("sushi", "everyday", "tea"))
-                .unwrap(),
+            temp.expand(&TestTemplateContext::new("sushi", "everyday", "tea")),
             "sushi everyday"
         );
     }


### PR DESCRIPTION
## Summary
- make `Template` generic over its context type and validate variables during parsing
- wire list and custom scheme templates to their specific context types
- simplify template expansion by removing separate validation paths

## Testing
- `just ci`

## Notes
This is a follow-up improvement that makes template usage more explicit and context-specific.