### PR TITLE
Refactor repo cache entry access

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ git2 = { version = "0.20.4" }
 git2_credentials = "0.15.0"
 regex = "1.12.3"
 remove_dir_all = "1.0.0"
-serde = { version = "1.0.228", features = ["derive"] }
+serde = { version = "1.0.228", features = ["derive", "rc"] }
 serde_json = "1.0.149"
 tempfile = "3.27.0"
 thiserror = "2.0.18"

--- a/src/application/usecase/list.rs
+++ b/src/application/usecase/list.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use chrono::{DateTime, Duration, TimeDelta, Utc};
 use color_eyre::eyre::eyre;
@@ -66,7 +66,7 @@ pub(crate) enum ListUsecaseError {
 #[derive(Debug)]
 pub(crate) struct ListUsecase {
     path_canonicalizer: Arc<dyn PathCanonicalizer>,
-    repo_cache: Arc<Mutex<dyn RepoCache>>,
+    repo_cache: Arc<dyn RepoCache>,
     repo_scan_service: RepoScanService,
 }
 
@@ -100,8 +100,7 @@ impl ListUsecase {
     }
 
     fn load_repo_cache(&self, context: &ListContext, options: &ListOptions) {
-        let mut repo_cache = self.repo_cache.lock().unwrap();
-        if let Err(err) = repo_cache.load(
+        if let Err(err) = self.repo_cache.load(
             &context.repo_cache_path,
             context.now,
             options.cache_expire_duration,
@@ -111,13 +110,12 @@ impl ListUsecase {
                 context.repo_cache_path.display()
             ));
             tracing::warn!("{}", err.format_error_chain());
-            repo_cache.clear(context.now);
+            self.repo_cache.clear();
         }
     }
 
-    fn store_repo_cache(&self, context: &ListContext) {
-        let mut repo_cache = self.repo_cache.lock().unwrap();
-        if let Err(err) = repo_cache.store(&context.repo_cache_path) {
+    fn persist_repo_cache(&self, context: &ListContext) {
+        if let Err(err) = self.repo_cache.persist(&context.repo_cache_path) {
             let err = eyre!(err).wrap_err(format!(
                 "failed to store repo cache ({})",
                 context.repo_cache_path.display()
@@ -131,7 +129,7 @@ impl ListUsecase {
 pub(crate) struct ListRoots<'a, I> {
     usecase: &'a ListUsecase,
     path_canonicalizer: Arc<dyn PathCanonicalizer>,
-    repo_cache: Arc<Mutex<dyn RepoCache>>,
+    repo_cache: Arc<dyn RepoCache>,
     repo_scan_service: RepoScanService,
     context: ListContext,
     roots: I,
@@ -139,7 +137,7 @@ pub(crate) struct ListRoots<'a, I> {
 
 impl<I> Drop for ListRoots<'_, I> {
     fn drop(&mut self) {
-        self.usecase.store_repo_cache(&self.context);
+        self.usecase.persist_repo_cache(&self.context);
     }
 }
 
@@ -193,7 +191,7 @@ where
 #[derive(Debug)]
 pub(crate) struct ListRoot {
     repo_scan: RepoScanService,
-    repo_cache: Arc<Mutex<dyn RepoCache>>,
+    repo_cache: Arc<dyn RepoCache>,
     visit_hidden_dirs: bool,
     visit_repo_subdirs: bool,
     include_bare_repo: bool,
@@ -221,7 +219,7 @@ impl ListRoot {
 
 #[derive(Debug)]
 pub(crate) struct ListRepos {
-    repo_cache: Arc<Mutex<dyn RepoCache>>,
+    repo_cache: Arc<dyn RepoCache>,
     visit_repo_subdirs: bool,
     include_bare_repo: bool,
     repos: Repos,
@@ -229,22 +227,19 @@ pub(crate) struct ListRepos {
 
 impl ListRepos {
     fn entry_to_repo(&self, entry: &OwnedEntry) -> Result<Option<CanonicalRepo>, ListUsecaseError> {
-        {
-            let mut cache_service = self.repo_cache.lock().unwrap();
-            if let Some(repo) = cache_service.get(entry.root(), entry.relative_path()) {
-                return Ok(Some(repo));
-            }
+        let cache_entry = self.repo_cache.entry(entry.root(), entry.relative_path());
+        if let Some(repo) = cache_entry.get() {
+            // TODO: check if the repo is still valid (e.g. by checking the mtime of the .git directory)
+            return Ok(Some(repo));
         }
 
-        let repo = entry.to_repo()?;
-        if let Some(repo) = &repo {
-            let mut cache_service = self.repo_cache.lock().unwrap();
-            if let Some(cached_repo) = cache_service.get(entry.root(), entry.relative_path()) {
-                return Ok(Some(cached_repo));
+        match entry.to_repo()? {
+            Some(repo) => {
+                cache_entry.publish(repo.clone());
+                Ok(Some(repo))
             }
-            cache_service.insert(entry.root(), repo);
+            None => Ok(None),
         }
-        Ok(repo)
     }
 }
 

--- a/src/domain/port/mod.rs
+++ b/src/domain/port/mod.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use crate::domain::port::repo_probe::RepoProbe;
 
@@ -21,5 +21,5 @@ pub(crate) struct Ports {
     pub(crate) dir_editor: Arc<dyn DirEditor>,
     pub(crate) repo_clone: Arc<dyn RepoClone>,
     pub(crate) repo_probe: Arc<dyn RepoProbe>,
-    pub(crate) repo_cache: Arc<Mutex<dyn RepoCache>>,
+    pub(crate) repo_cache: Arc<dyn RepoCache>,
 }

--- a/src/domain/port/repo_cache.rs
+++ b/src/domain/port/repo_cache.rs
@@ -5,30 +5,31 @@ use chrono::{DateTime, Duration, Utc};
 use crate::domain::model::{path_like::PathLike, repo::CanonicalRepo, root::CanonicalRoot};
 
 pub(crate) trait RepoCache: Debug {
-    /// Loads the cache at path.
+    /// Loads persisted entries into the in-memory cache.
     fn load(
-        &mut self,
+        &self,
         path: &dyn PathLike,
         now: DateTime<Utc>,
         expire_duration: Duration,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>>;
 
-    /// Clears the cache.
-    fn clear(&mut self, now: DateTime<Utc>);
+    /// Clears all cached entries.
+    fn clear(&self);
 
-    /// Stores the cache.
-    fn store(
-        &mut self,
+    /// Persists initialized entries.
+    fn persist(
+        &self,
         path: &dyn PathLike,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>>;
 
-    /// Gets the cached repository.
-    ///
-    /// Returns `None` if the repository is not cached.
-    fn get(&mut self, root: &CanonicalRoot, relative_path: &Path) -> Option<CanonicalRepo>;
+    /// Returns a handle to the cache entry for the given root/path pair.
+    fn entry(&self, root: &CanonicalRoot, relative_path: &Path) -> Box<dyn RepoCacheEntry>;
+}
 
-    /// Inserts the repository in the cache.
-    ///
-    /// Before calling `insert`, `load` or `clear` must be called.
-    fn insert(&mut self, root: &CanonicalRoot, repo: &CanonicalRepo);
+pub(crate) trait RepoCacheEntry: Debug {
+    /// Returns the cached repository if present.
+    fn get(&self) -> Option<CanonicalRepo>;
+
+    /// Publishes a repository value for this entry.
+    fn publish(&self, repo: CanonicalRepo);
 }

--- a/src/infrastructure/mod.rs
+++ b/src/infrastructure/mod.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use crate::{
     domain::port::Ports,
@@ -20,6 +20,6 @@ pub(crate) fn ports() -> Ports {
         dir_editor: Arc::new(FsDirEditor::new()),
         repo_clone: Arc::new(Git2RepoClone::new()),
         repo_probe: Arc::new(Git2RepoProbe::new()),
-        repo_cache: Arc::new(Mutex::new(JsonRepoCache::new())),
+        repo_cache: Arc::new(JsonRepoCache::new()),
     }
 }

--- a/src/infrastructure/persistence/repo_cache.rs
+++ b/src/infrastructure/persistence/repo_cache.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::{HashMap, hash_map::Entry},
     path::{Path, PathBuf},
+    sync::{Arc, Mutex},
 };
 
 use chrono::{DateTime, Duration, Utc};
@@ -13,116 +14,112 @@ use crate::{
             repo::{CanonicalRepo, Repo},
             root::{CanonicalRoot, Root},
         },
-        port::repo_cache::RepoCache,
+        port::repo_cache::{RepoCache, RepoCacheEntry},
     },
     util::file,
 };
 
-#[derive(Debug, Deserialize, Serialize)]
-pub(in crate::infrastructure) struct JsonRepoCache {
-    now: Option<DateTime<Utc>>,
-    cache: Cache,
-}
+#[derive(Debug)]
+pub(in crate::infrastructure) struct JsonRepoCache(Mutex<JsonRepoCacheInner>);
 
 impl JsonRepoCache {
     pub(in crate::infrastructure) fn new() -> Self {
-        Self {
+        Self(Mutex::new(JsonRepoCacheInner {
             now: None,
-            cache: Cache::default(),
-        }
+            expire_duration: None,
+            cache: JsonCache::default(),
+        }))
     }
+}
+
+#[derive(Debug)]
+struct JsonRepoCacheInner {
+    now: Option<DateTime<Utc>>,
+    expire_duration: Option<Duration>,
+    cache: JsonCache,
 }
 
 impl RepoCache for JsonRepoCache {
     fn load(
-        &mut self,
+        &self,
         path: &dyn PathLike,
         now: DateTime<Utc>,
         expire_duration: Duration,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
-        self.cache = file::load_json("repository cache", &path.as_real_path())?.unwrap_or_default();
-        self.cache.remove_invalid_repos(&now, expire_duration);
-        self.now = Some(now);
+        let mut this = self.0.lock().unwrap();
+        this.now = Some(now);
+        this.expire_duration = Some(expire_duration);
+        this.cache = file::load_json("repository cache", &path.as_real_path())?.unwrap_or_default();
+        this.cache.remove_invalid_repos(&now, expire_duration);
         Ok(())
     }
 
-    fn clear(&mut self, now: DateTime<Utc>) {
-        self.now = Some(now);
-        self.cache = Cache::default();
+    fn clear(&self) {
+        let mut this = self.0.lock().unwrap();
+        this.cache = JsonCache::default();
     }
 
-    fn store(
-        &mut self,
+    fn persist(
+        &self,
         path: &dyn PathLike,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
-        file::store_json("repository cache", &path.as_real_path(), &self.cache)?;
+        let mut this = self.0.lock().unwrap();
+        if let (Some(now), Some(expire_duration)) = (this.now, this.expire_duration) {
+            this.cache.remove_invalid_repos(&now, expire_duration);
+            file::store_json("repository cache", &path.as_real_path(), &this.cache)?;
+        }
         Ok(())
     }
 
-    fn get(&mut self, root: &CanonicalRoot, relative_path: &Path) -> Option<CanonicalRepo> {
-        let root_cache = self.cache.get_root_cache(root)?;
-        let repo_cache = root_cache.get_repo_cache(relative_path)?;
-        Some(repo_cache.to_canonical_repo(root.as_root(), relative_path.to_owned()))
-    }
-
-    fn insert(&mut self, root: &CanonicalRoot, repo: &CanonicalRepo) {
-        let root_cache = self.cache.insert_root_cache(root);
-        let now = self
-            .now
-            .expect("load or clear must be called before insert");
-        root_cache.insert_canonical_repo(repo, now);
+    fn entry(&self, root: &CanonicalRoot, relative_path: &Path) -> Box<dyn RepoCacheEntry> {
+        let mut this = self.0.lock().unwrap();
+        let root_cache = this.cache.entry(root);
+        let entry = root_cache.entry(relative_path.to_owned());
+        Box::new(RepoCacheEntryHandler {
+            now: this.now.unwrap_or_else(Utc::now),
+            root: root.as_root().clone(),
+            relative_path: relative_path.to_owned(),
+            entry,
+        })
     }
 }
 
 #[derive(Debug, Deserialize, Serialize, Default)]
 #[serde(rename_all = "camelCase")]
-struct Cache {
-    roots: HashMap<String, RootCacheEntry>,
+struct JsonCache {
+    roots: HashMap<String, JsonRootEntry>,
 }
 
-impl Cache {
+impl JsonCache {
     fn remove_invalid_repos(&mut self, now: &DateTime<Utc>, expire_duration: Duration) {
         for root_cache in self.roots.values_mut() {
             root_cache.remove_invalid_repos(now, expire_duration);
         }
     }
 
-    fn get_root_cache(&mut self, root: &CanonicalRoot) -> Option<&mut RootCacheEntry> {
-        let Entry::Occupied(entry) = self.roots.entry(root.name().to_owned()) else {
-            return None;
-        };
-
-        if !entry.get().is_valid(root) {
-            entry.remove();
-            return None;
-        }
-
-        Some(entry.into_mut())
-    }
-
-    fn insert_root_cache(&mut self, root: &CanonicalRoot) -> &mut RootCacheEntry {
+    fn entry(&mut self, root: &CanonicalRoot) -> &mut JsonRootEntry {
         match self.roots.entry(root.name().to_owned()) {
             Entry::Occupied(mut entry) => {
                 if !entry.get().is_valid(root) {
-                    *entry.get_mut() = RootCacheEntry::new(root);
+                    *entry.get_mut() = JsonRootEntry::new(root);
                 }
                 entry.into_mut()
             }
-            Entry::Vacant(entry) => entry.insert(RootCacheEntry::new(root)),
+            Entry::Vacant(entry) => entry.insert(JsonRootEntry::new(root)),
         }
     }
 }
 
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct RootCacheEntry {
+struct JsonRootEntry {
     real_path: PathBuf,
     display_path: PathBuf,
     canonical_path: PathBuf,
-    repos: HashMap<PathBuf, RepoCacheEntry>,
+    repos: HashMap<PathBuf, Arc<Mutex<Option<JsonRepoEntry>>>>,
 }
 
-impl RootCacheEntry {
+impl JsonRootEntry {
     fn new(root: &CanonicalRoot) -> Self {
         Self {
             real_path: root.path().as_real_path().to_owned(),
@@ -137,34 +134,33 @@ impl RootCacheEntry {
     }
 
     fn remove_invalid_repos(&mut self, now: &DateTime<Utc>, expire_duration: Duration) {
-        self.repos
-            .retain(|_, entry| entry.is_valid(now, expire_duration));
+        self.repos.retain(|_, entry| {
+            entry
+                .lock()
+                .unwrap()
+                .as_ref()
+                .is_some_and(|entry| entry.is_valid(now, expire_duration))
+        });
     }
 
-    fn get_repo_cache(&mut self, relative_path: &Path) -> Option<&RepoCacheEntry> {
-        self.repos.get(relative_path)
-    }
-
-    fn insert_canonical_repo(&mut self, repo: &CanonicalRepo, now: DateTime<Utc>) {
-        let relative_path = repo.relative_path().as_real_path().to_owned();
-        let entry = RepoCacheEntry {
-            timestamp: now,
-            canonical_path: repo.canonical_path().to_owned(),
-            bare: repo.bare(),
-        };
-        self.repos.insert(relative_path, entry);
+    fn entry(&mut self, relative_path: PathBuf) -> Arc<Mutex<Option<JsonRepoEntry>>> {
+        Arc::clone(
+            self.repos
+                .entry(relative_path)
+                .or_insert_with(|| Arc::new(Mutex::new(None))),
+        )
     }
 }
 
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct RepoCacheEntry {
+struct JsonRepoEntry {
     timestamp: DateTime<Utc>,
     canonical_path: PathBuf,
     bare: bool,
 }
 
-impl RepoCacheEntry {
+impl JsonRepoEntry {
     fn is_valid(&self, now: &DateTime<Utc>, expire_duration: Duration) -> bool {
         *now - self.timestamp <= expire_duration
     }
@@ -176,5 +172,31 @@ impl RepoCacheEntry {
     fn to_canonical_repo(&self, root: &Root, relative_path: PathBuf) -> CanonicalRepo {
         let repo = self.to_repo(root, relative_path);
         CanonicalRepo::new(repo, self.canonical_path.clone())
+    }
+}
+
+#[derive(Debug)]
+struct RepoCacheEntryHandler {
+    now: DateTime<Utc>,
+    root: Root,
+    relative_path: PathBuf,
+    entry: Arc<Mutex<Option<JsonRepoEntry>>>,
+}
+
+impl RepoCacheEntry for RepoCacheEntryHandler {
+    fn get(&self) -> Option<CanonicalRepo> {
+        let entry = self.entry.lock().unwrap();
+        entry
+            .as_ref()
+            .map(|repo| repo.to_canonical_repo(&self.root, self.relative_path.clone()))
+    }
+
+    fn publish(&self, repo: CanonicalRepo) {
+        let mut entry = self.entry.lock().unwrap();
+        *entry = Some(JsonRepoEntry {
+            timestamp: self.now,
+            canonical_path: repo.canonical_path().to_owned(),
+            bare: repo.bare(),
+        });
     }
 }


### PR DESCRIPTION
## Summary
- replace the repo cache mutex wrapper in the use case layer with an entry-based cache API
- move cache synchronization into the JSON repo cache implementation and rename cache persistence operations for clarity
- keep cache persistence as a best-effort internal behavior while preserving existing list behavior

## Testing
- cargo test